### PR TITLE
调整热度算法并增加重复校验

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -55,6 +55,10 @@ export const meApi = {
   get: () => http.get<User>('/api/me'),
   patch: (payload: { nickname?: string; avatar?: string }) =>
     http.patch<User>('/api/me', payload),
+  checkNickname: (nickname: string) =>
+    http.get<{ exists: boolean }>('/api/users/check-nickname', {
+      params: { nickname },
+    }),
 };
 
 // --------------- Books -------------------
@@ -90,6 +94,9 @@ export const bookApi = {
     coverUrl?: string;
     recommenderId?: number;
   }) => http.post<BookSummary>('/api/books', payload),
+
+  checkExist: (payload: { title: string; author?: string }) =>
+    http.get<{ exists: boolean }>('/api/books/check', { params: payload }),
 
   patch: (id: number, payload: Partial<Omit<BookSummary, 'id'>>) =>
     http.patch<BookSummary>(`/api/books/${id}`, payload),

--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -143,7 +143,7 @@ export default function Leaderboard({ items = [], onOpenUser, fetcher }) {
         </div>
 
         <div className="text-[11px] text-gray-400 mt-3 px-2">
-          {tab === "champion" ? "历史累计热度" : "近30天热度"} = 点赞×1 + 收藏×2 + 评论×3
+          {tab === "champion" ? "历史累计热度" : "近30天热度"} = 评论×1 + 收藏×2 + 点赞×3
         </div>
       </div>
     </div>

--- a/src/components/modals/UploadDrawer.jsx
+++ b/src/components/modals/UploadDrawer.jsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Upload, PlusCircle, X } from "lucide-react";
 import { ORIENTATIONS, CATEGORIES, TAGS } from "../../lib/constants";
 import { THEME } from "../../lib/theme";
-import { tagApi } from "../../api/sdk";
+import { tagApi, bookApi } from "../../api/sdk";
 import { useAppStore } from "../../store/AppStore";
 import { useCreateBook } from "../../api/hooks";
 import { useQueryClient } from "@tanstack/react-query";
@@ -211,6 +211,18 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
       return;
     }
     if (submitting) return;
+
+    // 书名+作者不得重复
+    try {
+      const resp = await bookApi.checkExist({ title, author });
+      const exists = resp?.data?.exists ?? resp?.exists;
+      if (exists) {
+        setToast({ msg: "已存在同名书籍", type: "error" });
+        return;
+      }
+    } catch (e) {
+      console.warn("check book duplicate failed", e);
+    }
 
     const payload = { title, author, tags, raw, orientation, category, blurb, summary };
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -9,13 +9,13 @@ export const classNames = (...arr) => arr.filter(Boolean).join(" ");
 
 /**
  * 热度算法（统一口径）
- * 权重：点赞×1、收藏×2、评论×3
+ * 权重：评论×1、收藏×2、点赞×3
  */
 export const heatScore = (item) => {
   const likes = Number(item?.likes || 0);
   const bookmarks = Number(item?.bookmarks || 0);
   const comments = Number(item?.comments || 0);
-  return likes * 1 + bookmarks * 2 + comments * 3;
+  return comments * 1 + bookmarks * 2 + likes * 3;
 };
 
 /** 安全数组：不是数组就返回空数组，避免 .map 报错 */

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -183,9 +183,22 @@ export default function ProfilePage() {
 
   const saveNick = async () => {
     try {
-      const r = await meApi.patch({ nickname: val, avatar });
+      const v = val.trim();
+      if (!v) {
+        setToast("请输入昵称");
+        return;
+      }
+
+      const ck = await meApi.checkNickname(v);
+      const exists = ck?.data?.exists ?? ck?.exists;
+      if (exists) {
+        setToast("昵称已被占用");
+        return;
+      }
+
+      const r = await meApi.patch({ nickname: v, avatar });
       const d = r?.data ?? r ?? {};
-      setNick(d.nick ?? val);
+      setNick(d.nick ?? v);
       setToast("保存成功");
     } catch (e) {
       console.error("update nickname failed", e);


### PR DESCRIPTION
## Summary
- 调整热度算法权重：评论×1、收藏×2、点赞×3
- 闪电上传前检查书名+作者是否重复
- 修改昵称时校验唯一性

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0c84ed45483318abbb89be6502ca0