### PR TITLE
feat: add personal booklist management

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -153,6 +153,48 @@ export const bookApi = {
     http.get<{ ids: number[] } | number[]>('/api/books/bookmarks', { params: { userId } }),
 };
 
+// --------------- BookSheets --------------
+export interface SheetItem {
+  id: number;
+  name: string;
+  bookCount?: number;
+  updatedAt?: string | number;
+}
+
+export interface SheetBook {
+  id: number;
+  title: string;
+  author?: string;
+  orientation?: string;
+  category?: string;
+  rating?: number;
+  review?: string;
+  createdAt?: string | number;
+}
+
+export const sheetApi = {
+  list: (userId: number) =>
+    http.get<{ list: SheetItem[] }>(`/api/users/${userId}/sheets`),
+  create: (userId: number, payload: { name: string }) =>
+    http.post<SheetItem>(`/api/users/${userId}/sheets`, payload),
+  update: (id: number, payload: { name: string }) =>
+    http.patch<SheetItem>(`/api/sheets/${id}`, payload),
+  delete: (id: number) => http.delete<void>(`/api/sheets/${id}`),
+  books: (sheetId: number) =>
+    http.get<{ list: SheetBook[] }>(`/api/sheets/${sheetId}/books`),
+  addBook: (
+    sheetId: number,
+    payload: Omit<SheetBook, 'id' | 'createdAt'>,
+  ) => http.post<SheetBook>(`/api/sheets/${sheetId}/books`, payload),
+  updateBook: (
+    sheetId: number,
+    bookId: number,
+    payload: Partial<Omit<SheetBook, 'id' | 'createdAt'>>,
+  ) => http.patch<SheetBook>(`/api/sheets/${sheetId}/books/${bookId}`, payload),
+  removeBook: (sheetId: number, bookId: number) =>
+    http.delete<void>(`/api/sheets/${sheetId}/books/${bookId}`),
+};
+
 // --------------- Tags --------------------
 export const tagApi = {
   suggest: (q: string) =>

--- a/src/components/BookSheetPanel.jsx
+++ b/src/components/BookSheetPanel.jsx
@@ -1,0 +1,189 @@
+// src/components/BookSheetPanel.jsx
+import React from "react";
+import { useAppStore } from "../store/AppStore";
+import { THEME } from "../lib/theme";
+import { classNames, formatDate } from "../lib/utils";
+
+export default function BookSheetPanel() {
+  const {
+    sheets,
+    sheetBooks,
+    activeSheetId,
+    setActiveSheetId,
+    addSheet,
+    renameSheet,
+    removeSheet,
+    addBookToSheet,
+    updateBookInSheet,
+    removeBookFromSheet,
+  } = useAppStore();
+
+  const activeSheet = sheets.find((s) => s.id === activeSheetId);
+
+  const handleAddSheet = async () => {
+    const name = prompt("输入书单名");
+    if (name) await addSheet(name);
+  };
+
+  const handleRenameSheet = async (id, name) => {
+    const v = prompt("修改书单名", name);
+    if (v && v !== name) await renameSheet(id, v);
+  };
+
+  const handleAddBook = async () => {
+    if (!activeSheet) return;
+    const title = prompt("书名");
+    if (!title) return;
+    const author = prompt("作者") || "";
+    const orientation = prompt("性向") || "";
+    const category = prompt("类型") || "";
+    const ratingStr = prompt("评分（1-10）") || "";
+    const rating = ratingStr ? Number(ratingStr) : undefined;
+    const review = prompt("评价") || "";
+    await addBookToSheet(activeSheet.id, {
+      title,
+      author,
+      orientation,
+      category,
+      rating,
+      review,
+    });
+  };
+
+  const handleEditBook = async (b) => {
+    const title = prompt("书名", b.title);
+    if (!title) return;
+    const author = prompt("作者", b.author || "") || "";
+    const orientation = prompt("性向", b.orientation || "") || "";
+    const category = prompt("类型", b.category || "") || "";
+    const ratingStr = prompt(
+      "评分（1-10）",
+      b.rating != null ? String(b.rating) : ""
+    ) || "";
+    const rating = ratingStr ? Number(ratingStr) : undefined;
+    const review = prompt("评价", b.review || "") || "";
+    await updateBookInSheet(activeSheet.id, b.id, {
+      title,
+      author,
+      orientation,
+      category,
+      rating,
+      review,
+    });
+  };
+
+  return (
+    <div className="flex">
+      <div
+        className="w-48 flex-shrink-0 pr-2 border-r"
+        style={{ borderColor: THEME.border }}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <span className="font-semibold">书单</span>
+          <button onClick={handleAddSheet} className="text-xs text-blue-500">
+            新增
+          </button>
+        </div>
+        <ul className="text-sm space-y-1">
+          {sheets.map((s) => (
+            <li
+              key={s.id}
+              className={classNames(
+                "flex items-center gap-1 p-1 rounded cursor-pointer",
+                activeSheetId === s.id && "bg-amber-50"
+              )}
+            >
+              <span
+                className="flex-1 truncate"
+                onClick={() => setActiveSheetId(s.id)}
+              >
+                {s.name}
+              </span>
+              <button
+                onClick={() => handleRenameSheet(s.id, s.name)}
+                className="text-[10px] text-gray-400"
+              >
+                改
+              </button>
+              <button
+                onClick={() => removeSheet(s.id)}
+                className="text-[10px] text-red-500"
+              >
+                删
+              </button>
+            </li>
+          ))}
+          {sheets.length === 0 && <li className="text-gray-400">暂无书单</li>}
+        </ul>
+      </div>
+
+      <div className="flex-1 pl-4">
+        {activeSheet ? (
+          <>
+            <div className="flex items-center justify-between mb-2">
+              <span className="font-semibold">
+                {activeSheet.name}（{sheetBooks.length}）
+              </span>
+              <button
+                onClick={handleAddBook}
+                className="text-xs text-blue-500"
+              >
+                添加书籍
+              </button>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {sheetBooks.map((b) => (
+                <div
+                  key={b.id}
+                  className="p-3 rounded border"
+                  style={{ borderColor: THEME.border }}
+                >
+                  <div className="flex justify-between">
+                    <div>
+                      <div className="font-medium">{b.title}</div>
+                      <div className="text-xs text-gray-600">{b.author}</div>
+                      <div className="text-[11px] text-gray-500">
+                        {b.orientation} / {b.category}
+                      </div>
+                      <div className="text-[11px] text-gray-500">
+                        评分: {b.rating ?? "-"}
+                      </div>
+                      {b.review && (
+                        <div className="text-xs text-gray-600 mt-1">
+                          {b.review}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <button
+                        onClick={() => handleEditBook(b)}
+                        className="text-[10px] text-blue-500"
+                      >
+                        编辑
+                      </button>
+                      <button
+                        onClick={() => removeBookFromSheet(activeSheet.id, b.id)}
+                        className="text-[10px] text-red-500"
+                      >
+                        删除
+                      </button>
+                    </div>
+                  </div>
+                  <div className="text-[10px] text-gray-400 mt-1">
+                    加入: {formatDate(b.createdAt)}
+                  </div>
+                </div>
+              ))}
+              {sheetBooks.length === 0 && (
+                <div className="text-sm text-gray-500">暂无书籍</div>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="text-sm text-gray-500">请选择书单</div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -7,6 +7,7 @@ import { Edit3 } from "lucide-react";
 import { THEME } from "../lib/theme";
 import { classNames } from "../lib/utils";
 import NovelCard from "../components/NovelCard";
+import BookSheetPanel from "../components/BookSheetPanel";
 import { useAppStore } from "../store/AppStore";
 import { meApi } from "../api/sdk";
 
@@ -96,10 +97,6 @@ export function BookshelfSection() {
 
   const favorites = items.filter((i) => savedIds.has(i.id));
   const myRecs = items.filter((i) => i?.recommender?.name === nick);
-  const sheets = [
-    { name: "我的躺赢甜文", count: 12, updated: "今天" },
-    { name: "破案爽感清单", count: 8, updated: "2天前" },
-  ];
 
   const list = tab === "fav" ? favorites : myRecs;
 
@@ -139,17 +136,7 @@ export function BookshelfSection() {
       </div>
 
       {tab === "sheet" ? (
-        <div className="p-4 rounded-2xl border bg-white" style={{ borderColor: THEME.border }}>
-          <div className="font-semibold mb-2">个人书单（{sheets.length}）</div>
-          <ul className="text-sm space-y-1">
-            {sheets.map((s, i) => (
-              <li key={i} className="flex items-center justify-between">
-                <span>· {s.name}（{s.count}本）</span>
-                <span className="text-gray-400">{s.updated}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
+        <BookSheetPanel />
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {list.map((item) => (


### PR DESCRIPTION
## Summary
- add sheet API client for personal booklists and entries
- manage personal booklists in global store and render new BookSheetPanel
- integrate personal booklists into profile bookshelf section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a0d659eecc8331928c6b4de3de71ed