### PR TITLE
fix: render book sheets after refresh

### DIFF
--- a/src/components/BookSheetPanel.jsx
+++ b/src/components/BookSheetPanel.jsx
@@ -21,174 +21,199 @@ export default function BookSheetPanel() {
 
   const activeSheet = sheets.find((s) => s.id === activeSheetId);
 
-    const [listFormOpen, setListFormOpen] = useState(false);
-    const [editingSheet, setEditingSheet] = useState(null);
-    const [bookFormOpen, setBookFormOpen] = useState(false);
-    const [editingBook, setEditingBook] = useState(null);
+  const [listFormOpen, setListFormOpen] = useState(false);
+  const [editingSheet, setEditingSheet] = useState(null);
+  const [bookFormOpen, setBookFormOpen] = useState(false);
+  const [editingBook, setEditingBook] = useState(null);
 
   const handleAddSheet = () => {
     setEditingSheet(null);
-      setListFormOpen(true);
+    setListFormOpen(true);
   };
 
   const handleRenameSheet = (id, name) => {
     setEditingSheet({ id, name });
-      setListFormOpen(true);
+    setListFormOpen(true);
   };
 
-    const submitSheet = async (payload) => {
-      const name = payload?.name || "";
-      if (editingSheet) await renameSheet(editingSheet.id, name);
-      else await addSheet(name);
-      setListFormOpen(false);
-    };
+  const handleRemoveSheet = (id) => {
+    if (window.confirm("确定删除该书单吗？")) removeSheet(id);
+  };
+
+  const submitSheet = async (payload) => {
+    const name = payload?.name || "";
+    if (editingSheet) await renameSheet(editingSheet.id, name);
+    else await addSheet(name);
+    setListFormOpen(false);
+  };
 
   const handleAddBook = () => {
     if (!activeSheet) return;
     setEditingBook(null);
-      setBookFormOpen(true);
+    setBookFormOpen(true);
   };
 
   const handleEditBook = (b) => {
     setEditingBook(b);
-      setBookFormOpen(true);
+    setBookFormOpen(true);
   };
 
   const submitBook = async (payload) => {
     if (!activeSheet) return;
     if (editingBook) await updateBookInSheet(activeSheet.id, editingBook.id, payload);
     else await addBookToSheet(activeSheet.id, payload);
-      setBookFormOpen(false);
+    setBookFormOpen(false);
   };
 
   return (
     <>
-      <div className="flex">
-        <div
-          className="w-48 flex-shrink-0 pr-2 border-r"
-          style={{ borderColor: THEME.border }}
-        >
-        <div className="flex items-center justify-between mb-2">
-          <span className="font-semibold">书单</span>
+      <div className="mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <span className="font-semibold">我的书单</span>
           <button onClick={handleAddSheet} className="text-xs text-blue-500">
             新增
           </button>
         </div>
-        <ul className="text-sm space-y-1">
-          {sheets.map((s) => (
-            <li
-              key={s.id}
-              className={classNames(
-                "flex items-center gap-1 p-1 rounded cursor-pointer",
-                activeSheetId === s.id && "bg-amber-50"
-              )}
-            >
-              <span
-                className="flex-1 truncate"
+        {sheets.length === 0 ? (
+          <div className="text-sm text-gray-500">暂无书单</div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {sheets.map((s) => (
+              <div
+                key={s.id}
                 onClick={() => setActiveSheetId(s.id)}
+                className={classNames(
+                  "group relative p-4 rounded-2xl border cursor-pointer transition hover:shadow-sm",
+                  activeSheetId === s.id && "ring-2 ring-rose-300"
+                )}
+                style={{ borderColor: THEME.border }}
               >
-                {s.name}
-              </span>
-              <button
-                onClick={() => handleRenameSheet(s.id, s.name)}
-                className="text-[10px] text-gray-400"
-              >
-                改
-              </button>
-              <button
-                onClick={() => removeSheet(s.id)}
-                className="text-[10px] text-red-500"
-              >
-                删
-              </button>
-            </li>
-          ))}
-          {sheets.length === 0 && <li className="text-gray-400">暂无书单</li>}
-        </ul>
+                <div className="font-semibold mb-1 truncate">{s.name}</div>
+                <div className="text-xs text-gray-500 mb-1">
+                  {s.bookCount ?? 0} 本书
+                </div>
+                <div className="text-[11px] text-gray-400">
+                  更新 {formatDate(s.updatedAt)}
+                </div>
+                <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 flex gap-1 text-[11px]">
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRenameSheet(s.id, s.name);
+                    }}
+                    className="text-blue-500"
+                  >
+                    编辑
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRemoveSheet(s.id);
+                    }}
+                    className="text-red-500"
+                  >
+                    删除
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
-      <div className="flex-1 pl-4">
-        {activeSheet ? (
-          <>
-            <div className="flex items-center justify-between mb-2">
-              <span className="font-semibold">
-                {activeSheet.name}（{sheetBooks.length}）
-              </span>
-              <button
-                onClick={handleAddBook}
-                className="text-xs text-blue-500"
-              >
-                添加书籍
-              </button>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      {activeSheet ? (
+        <>
+          <div className="flex items-center justify-between mb-3">
+            <span className="font-semibold">
+              {activeSheet.name}（{sheetBooks.length}）
+            </span>
+            <button
+              onClick={handleAddBook}
+              className="text-xs text-blue-500"
+            >
+              添加书籍
+            </button>
+          </div>
+          {sheetBooks.length === 0 ? (
+            <div className="text-sm text-gray-500">暂无书籍</div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
               {sheetBooks.map((b) => (
                 <div
                   key={b.id}
-                  className="p-3 rounded border"
+                  className="group flex gap-3 p-4 border rounded-2xl"
                   style={{ borderColor: THEME.border }}
                 >
-                  <div className="flex justify-between">
-                    <div>
-                      <div className="font-medium">{b.title}</div>
-                      <div className="text-xs text-gray-600">{b.author}</div>
-                      <div className="text-[11px] text-gray-500">
-                        {b.orientation} / {b.category}
+                  <div className="w-20 h-28 rounded-lg overflow-hidden bg-gray-100 flex items-center justify-center text-gray-400 flex-shrink-0">
+                    {b.coverUrl ? (
+                      <img
+                        src={b.coverUrl}
+                        alt="cover"
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <span className="text-sm">{b.title?.[0]}</span>
+                    )}
+                  </div>
+                  <div className="flex-1 flex flex-col">
+                    <div className="font-medium truncate">{b.title}</div>
+                    {b.author && (
+                      <div className="text-xs text-gray-600 truncate">
+                        {b.author}
                       </div>
-                      <div className="text-[11px] text-gray-500">
-                        评分: {b.rating ?? "-"}
-                      </div>
-                      {b.review && (
-                        <div className="text-xs text-gray-600 mt-1">
-                          {b.review}
-                        </div>
-                      )}
+                    )}
+                    <div className="text-[11px] text-gray-500">
+                      {b.orientation} / {b.category}
                     </div>
-                    <div className="flex flex-col gap-1">
+                    {b.rating != null && (
+                      <div className="text-[11px] text-gray-500">
+                        评分: {b.rating}
+                      </div>
+                    )}
+                    {b.review && (
+                      <div className="text-xs text-gray-600 mt-1 line-clamp-2">
+                        {b.review}
+                      </div>
+                    )}
+                    <div className="mt-auto flex gap-2 opacity-0 group-hover:opacity-100 text-[11px] pt-2">
                       <button
                         onClick={() => handleEditBook(b)}
-                        className="text-[10px] text-blue-500"
+                        className="text-blue-500"
                       >
                         编辑
                       </button>
                       <button
                         onClick={() => removeBookFromSheet(activeSheet.id, b.id)}
-                        className="text-[10px] text-red-500"
+                        className="text-red-500"
                       >
                         删除
                       </button>
                     </div>
                   </div>
-                  <div className="text-[10px] text-gray-400 mt-1">
-                    加入: {formatDate(b.createdAt)}
-                  </div>
                 </div>
               ))}
-              {sheetBooks.length === 0 && (
-                <div className="text-sm text-gray-500">暂无书籍</div>
-              )}
             </div>
-          </>
-        ) : (
-          <div className="text-sm text-gray-500">请选择书单</div>
-        )}
-      </div>
-      </div>
-        <BottomSheetForm
-          mode="list"
-          open={listFormOpen}
-          onClose={() => setListFormOpen(false)}
-          onSubmit={submitSheet}
-          initialValues={editingSheet || {}}
-        />
-        <BottomSheetForm
-          mode="book"
-          open={bookFormOpen}
-          onClose={() => setBookFormOpen(false)}
-          onSubmit={submitBook}
-          initialValues={editingBook || {}}
-        />
-      </>
-    );
-  }
+          )}
+        </>
+      ) : (
+        <div className="text-sm text-gray-500">请选择书单</div>
+      )}
+
+      <BottomSheetForm
+        mode="list"
+        open={listFormOpen}
+        onClose={() => setListFormOpen(false)}
+        onSubmit={submitSheet}
+        initialValues={editingSheet || {}}
+      />
+      <BottomSheetForm
+        mode="book"
+        open={bookFormOpen}
+        onClose={() => setBookFormOpen(false)}
+        onSubmit={submitBook}
+        initialValues={editingBook || {}}
+      />
+    </>
+  );
+}
 

--- a/src/store/AppStore.jsx
+++ b/src/store/AppStore.jsx
@@ -163,7 +163,9 @@ export function AppProvider({ children }) {
     if (!user?.id) return;
     try {
       const res = await sheetApi.list(user.id);
-      const list = res?.data?.list ?? res?.list ?? [];
+      // 兼容多种返回结构：数组 / {list: [...]} / AxiosResponse
+      const data = res?.data ?? res ?? [];
+      const list = Array.isArray(data) ? data : data.list ?? [];
       setSheets(list);
       if (list.length && !activeSheetId) setActiveSheetId(list[0].id);
       localStorage.setItem(`sheets_${user.id}`, JSON.stringify(list));
@@ -184,7 +186,8 @@ export function AppProvider({ children }) {
     if (!sheetId) return;
     try {
       const res = await sheetApi.books(sheetId);
-      const list = res?.data?.list ?? res?.list ?? [];
+      const data = res?.data ?? res ?? [];
+      const list = Array.isArray(data) ? data : data.list ?? [];
       setSheetBooks(list);
       if (user?.id)
         localStorage.setItem(


### PR DESCRIPTION
## Summary
- handle sheet API responses with flexible data extraction
- redesign BookSheetPanel as card grid for sheets and books

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0e427ef448331bc61ba8ae4781da2