### PR TITLE
feat: remove cover upload and add book transfer

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -16,7 +16,6 @@ export interface BookSummary {
   orientation?: string;
   category?: string;
   blurb?: string;
-  coverUrl?: string;
   tags?: string[];
   likes?: number;
   bookmarks?: number;
@@ -91,7 +90,6 @@ export const bookApi = {
     blurb?: string;
     summary?: string;
     tags?: string[];
-    coverUrl?: string;
     recommenderId?: number;
   }) => http.post<BookSummary>('/api/books', payload),
 
@@ -193,6 +191,11 @@ export const sheetApi = {
   ) => http.patch<SheetBook>(`/api/sheets/${sheetId}/books/${bookId}`, payload),
   removeBook: (sheetId: number, bookId: number) =>
     http.delete<void>(`/api/sheets/${sheetId}/books/${bookId}`),
+  moveBook: (fromId: number, bookId: number, toId: number) =>
+    http.post<{ moved: boolean; fromListId: number; toListId: number; bookId: number }>(
+      `/api/sheets/${fromId}/books/${bookId}/move`,
+      { toListId: toId },
+    ),
 };
 
 // --------------- Tags --------------------

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -15,7 +15,6 @@ export interface Book {
   blurb?: string;
   summary?: string;
   tags: string[];
-  coverUrl?: string;
   likes: number;
   bookmarks: number;
   comments: number;
@@ -64,7 +63,6 @@ export interface BookCreateReq {
   blurb?: string;
   summary?: string;
   tags?: string[];
-  coverUrl?: string;
   recommenderId?: number;
 }
 export type BookUpdateReq = Partial<Omit<BookCreateReq, 'recommenderId'>>;

--- a/src/components/modals/BottomSheetForm.jsx
+++ b/src/components/modals/BottomSheetForm.jsx
@@ -32,6 +32,7 @@ export default function BottomSheetForm({
         if (saved) data = JSON.parse(saved);
       } catch {}
     }
+    const { cover, coverUrl, ...rest } = data;
     setForm({
       name: "",
       intro: "",
@@ -44,7 +45,7 @@ export default function BottomSheetForm({
       review: "",
       summary: "",
       tags: "",
-      ...data,
+      ...rest,
     });
     setErrors({});
   }, [open, storageKey, initialValues]);
@@ -77,7 +78,7 @@ export default function BottomSheetForm({
 
   const handleSubmit = () => {
     if (!validate()) return;
-    const payload = { ...form };
+    const { cover, coverUrl, ...payload } = form;
     onSubmit(payload);
     try {
       localStorage.removeItem(storageKey);
@@ -254,16 +255,6 @@ export default function BottomSheetForm({
                       onChange={handleChange("tags")}
                       className="w-full border rounded-xl px-3 py-2"
                       style={{ borderColor: THEME.border }}
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm mb-1">封面</label>
-                    <input
-                      type="file"
-                      onChange={(e) =>
-                        setForm((f) => ({ ...f, cover: e.target.files?.[0] || null }))
-                      }
-                      style={{ display: "block" }}
                     />
                   </div>
                 </div>

--- a/src/components/modals/MoveBookModal.jsx
+++ b/src/components/modals/MoveBookModal.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+
+export default function MoveBookModal({ open, sheets = [], onCancel, onConfirm }) {
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    if (open) {
+      setSelected(sheets[0]?.id ?? null);
+    }
+  }, [open, sheets]);
+
+  const body = (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-[1000] flex items-center justify-center"
+          style={{ background: "rgba(0,0,0,0.3)" }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onCancel}
+        >
+          <motion.div
+            onClick={(e) => e.stopPropagation()}
+            className="w-[92%] max-w-[440px] rounded-2xl p-5"
+            style={{
+              background: "rgba(255,255,255,0.82)",
+              backdropFilter: "saturate(130%) blur(10px)",
+              WebkitBackdropFilter: "saturate(130%) blur(10px)",
+              border: "1px solid rgba(255,255,255,0.65)",
+              boxShadow: "0 18px 40px rgba(0,0,0,0.12)",
+            }}
+            initial={{ scale: 0.98, y: 8, opacity: 0 }}
+            animate={{ scale: 1, y: 0, opacity: 1 }}
+            exit={{ scale: 0.98, y: 8, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 420, damping: 34, mass: 0.7 }}
+          >
+            <div className="text-lg font-semibold">转移到其他书单</div>
+            <div className="mt-3 max-h-[50vh] overflow-auto space-y-2">
+              {sheets.length === 0 && (
+                <div className="text-sm text-gray-500">暂无其他书单</div>
+              )}
+              {sheets.map((s) => (
+                <label key={s.id} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="move-sheet"
+                    value={s.id}
+                    checked={selected === s.id}
+                    onChange={() => setSelected(s.id)}
+                  />
+                  <span>{s.name || s.title}</span>
+                </label>
+              ))}
+            </div>
+            <div className="flex justify-end gap-2 mt-5">
+              <button
+                onClick={onCancel}
+                className="px-3 py-2 rounded-full border text-sm"
+                style={{ borderColor: "#f1e6ea", background: "#fff7fa" }}
+              >
+                取消
+              </button>
+              <button
+                onClick={() => selected && onConfirm(selected)}
+                disabled={!selected}
+                className="px-3 py-2 rounded-full text-sm text-white disabled:opacity-50"
+                style={{ background: "linear-gradient(135deg,#F472B6,#FB7185)" }}
+              >
+                确定
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+
+  return createPortal(body, document.body);
+}

--- a/src/components/ui/BookListRow.jsx
+++ b/src/components/ui/BookListRow.jsx
@@ -8,7 +8,7 @@ import { classNames } from "../../lib/utils";
  *  - book: { title, author, orientation, category, rating, reason/intro/tags ... }
  *  - onEdit, onDelete
  */
-export default function BookListRow({ book = {}, onEdit, onDelete }) {
+export default function BookListRow({ book = {}, onEdit, onDelete, onMove }) {
   const title = book.title || book.name || "未命名书籍";
   const author = book.author || "未知作者";
   const orientation = book.orientation || book.sexuality || "";
@@ -77,6 +77,12 @@ export default function BookListRow({ book = {}, onEdit, onDelete }) {
           className="text-xs text-gray-500 hover:text-gray-700"
         >
           编辑
+        </button>
+        <button
+          onClick={onMove}
+          className="text-xs text-gray-500 hover:text-gray-700"
+        >
+          转移
         </button>
         <button
           onClick={onDelete}

--- a/src/store/AppStore.jsx
+++ b/src/store/AppStore.jsx
@@ -295,6 +295,19 @@ export function AppProvider({ children }) {
     }
   };
 
+  const moveBookToSheet = async (fromId, book, toId) => {
+    try {
+      await sheetApi.moveBook(fromId, book.id, toId);
+      if (fromId === activeSheetId)
+        setSheetBooks((prev) => prev.filter((x) => x.id !== book.id));
+      if (toId === activeSheetId)
+        setSheetBooks((prev) => [...prev, book]);
+    } catch (e) {
+      console.error("move book to sheet failed", e);
+      throw e;
+    }
+  };
+
   // ===== 通知中心 =====
   const [notifications, setNotifications] = useState([]);
   const [notifyOpen, setNotifyOpen] = useState(false);
@@ -715,6 +728,7 @@ export function AppProvider({ children }) {
       addBookToSheet,
       updateBookInSheet,
       removeBookFromSheet,
+      moveBookToSheet,
 
       // 通知
       notifications,
@@ -755,6 +769,7 @@ export function AppProvider({ children }) {
       notifications,
       notifyOpen,
       unreadCount,
+      moveBookToSheet,
     ]
   );
 


### PR DESCRIPTION
## Summary
- remove all cover upload fields and request payloads
- add button and modal to move books between lists
- expose moveBook API and store method

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f088754c8331b91d98018e906f8d