### PR TITLE
fix: refresh notifications and reply UX

### DIFF
--- a/src/components/modals/CommentsDrawer.jsx
+++ b/src/components/modals/CommentsDrawer.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Heart } from "lucide-react";
 import { THEME } from "../../lib/theme";
@@ -10,6 +10,12 @@ export default function CommentsDrawer({ open, onClose, item, list, onAdd, onLik
   const [replyText, setReplyText] = useState("");
   const [replyingId, setReplyingId] = useState(null);
   const [openReplies, setOpenReplies] = useState({});
+  const replyInputRef = useRef(null);
+
+  // 回复时自动聚焦输入框
+  useEffect(() => {
+    if (replyingId != null) replyInputRef.current?.focus();
+  }, [replyingId]);
 
   // 限制视觉缩进层级，避免嵌套过深导致排版混乱
   const MAX_INDENT_DEPTH = 2;
@@ -32,6 +38,7 @@ export default function CommentsDrawer({ open, onClose, item, list, onAdd, onLik
       await onAdd(replyText.trim(), parentId);
       setReplyText("");
       setReplyingId(null);
+      setOpenReplies((o) => ({ ...o, [parentId]: true }));
     } catch (e) {
       console.error("回复失败", e);
     }
@@ -71,6 +78,7 @@ export default function CommentsDrawer({ open, onClose, item, list, onAdd, onLik
                 onClick={() => {
                   setReplyingId(c.id);
                   setReplyText("");
+                  setOpenReplies((o) => ({ ...o, [c.id]: true }));
                 }}
                 className="hover:text-pink-500"
               >
@@ -89,6 +97,7 @@ export default function CommentsDrawer({ open, onClose, item, list, onAdd, onLik
           {replyingId === c.id && (
             <div className="flex items-center gap-2 mt-2">
               <input
+                ref={replyInputRef}
                 value={replyText}
                 onChange={(e) => setReplyText(e.target.value)}
                 placeholder="回复……"

--- a/src/store/AppStore.jsx
+++ b/src/store/AppStore.jsx
@@ -679,6 +679,25 @@ export function AppProvider({ children }) {
     };
   }, [user?.id]);
 
+  // 打开通知中心时刷新，确保外部互动后能获取最新通知
+  useEffect(() => {
+    if (!notifyOpen || !user?.id) return;
+    let aborted = false;
+    (async () => {
+      try {
+        const res = await notificationApi.list({ userId: user.id, page: 1, size: 20 });
+        const data = res?.data || res || {};
+        const list = data.list ?? data.items ?? [];
+        if (!aborted) setNotifications(list);
+      } catch (e) {
+        console.error("load notifications failed", e);
+      }
+    })();
+    return () => {
+      aborted = true;
+    };
+  }, [notifyOpen, user?.id]);
+
   const store = useMemo(
     () => ({
       // 基础


### PR DESCRIPTION
## Summary
- refresh notifications when opening the drawer so likes/comments/bookmarks on lightning uploads and comment interactions appear
- keep comment threads open after sending replies and autofocus the reply input

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a10aa5f2148331a929299b32ca07a8