### PR TITLE
feat: implement credential login flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,6 +41,7 @@ function Shell() {
     notifyOpen,
     setNotifyOpen,
     setPage,
+    user,
   } = useAppStore();
 
   // 发布上传（保持原有本地插卡行为；UploadDrawer 里也已接上后端，二者兼容）
@@ -97,7 +98,7 @@ function Shell() {
       {/* 右下角悬浮 + 按钮：当评论抽屉打开时隐藏，避免遮挡输入框 */}
       {!commentsOpen.open && (
         <button
-          onClick={() => setShowUpload(true)}
+          onClick={() => (user ? setShowUpload(true) : setAuthOpen(true))}
           title="闪电上传"
           className="fixed bottom-6 right-6 rounded-full shadow-lg flex items-center justify-center"
           style={{

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -16,25 +16,16 @@ import {
 
 /* ========== Auth ========== */
 
-// 1) 发送短信验证码
-export const useSendPhoneCode = () =>
+export const useAuthRegister = () =>
   useMutation({
-    mutationFn: (payload: Parameters<typeof authApi.sendPhoneCode>[0]) =>
-      authApi.sendPhoneCode(payload),
+    mutationFn: (payload: Parameters<typeof authApi.register>[0]) =>
+      authApi.register(payload),
   });
 
-// 2) 微信登录（是否写入 token 由调用方决定）
-export const useWechatLogin = () =>
+export const useAuthLogin = () =>
   useMutation({
-    mutationFn: (payload: Parameters<typeof authApi.wechatLogin>[0]) =>
-      authApi.wechatLogin(payload),
-  });
-
-// 3) 手机验证码登录（是否写入 token 由调用方决定）
-export const usePhoneLogin = () =>
-  useMutation({
-    mutationFn: (payload: Parameters<typeof authApi.phoneLogin>[0]) =>
-      authApi.phoneLogin(payload),
+    mutationFn: (payload: Parameters<typeof authApi.login>[0]) =>
+      authApi.login(payload),
   });
 
 /* ========== Me ========== */

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -26,7 +26,13 @@ http.interceptors.response.use(
     }
     return res;
   },
-  (err) => Promise.reject(err)
+  (err) => {
+    if (err?.response?.status === 401) {
+      localStorage.removeItem("token");
+      window.dispatchEvent(new Event("auth:logout"));
+    }
+    return Promise.reject(err);
+  }
 );
 
 export default http;

--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -39,14 +39,10 @@ export interface CommentItem {
 
 // --------------- Auth --------------------
 export const authApi = {
-  // 发送短信验证码
-  sendPhoneCode: (payload: { phone: string }) =>
-    http.post<{ sent: boolean; ttl: number }>('/api/auth/phone/code', payload),
-
-  wechatLogin: (payload: { wechatCode: string }) =>
-    http.post<{ token: string; user: User }>('/api/auth/wechat/login', payload),
-  phoneLogin: (payload: { phone: string; code: string }) =>
-    http.post<{ token: string; user: User }>('/api/auth/phone/login', payload),
+  register: (payload: { handle: string; password: string }) =>
+    http.post<{ ok: boolean }>('/api/auth/register', payload),
+  login: (payload: { handle: string; password: string }) =>
+    http.post<{ token: string; user: User }>('/api/auth/login', payload),
 };
 
 // --------------- Me ----------------------

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -137,7 +137,7 @@ export default function Header(props) {
 
           {/* 闪电上传 */}
           <button
-            onClick={onOpenUpload}
+            onClick={() => (store.user ? onOpenUpload() : store.setAuthOpen(true))}
             className="ml-2 hidden md:inline-flex items-center gap-2 px-3 py-2 rounded-full text-white shadow"
             style={{
               background:
@@ -219,7 +219,7 @@ export default function Header(props) {
             className="relative ml-1"
             title="通知中心"
             type="button"
-            onClick={() => store.setNotifyOpen(true)}
+            onClick={() => (store.user ? store.setNotifyOpen(true) : store.setAuthOpen(true))}
           >
             <Bell className="w-6 h-6 text-gray-700" />
             {store.unreadCount > 0 && (


### PR DESCRIPTION
## Summary
- switch auth API to handle/password login & registration
- guard interactive actions behind login and persist user state
- handle 401 globally and expose new auth hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1195d21f88331ae61bdcdd19cd1d1