### PR TITLE
Display user nicknames instead of usernames

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,7 +68,7 @@ function Shell() {
       likes: 0,
       bookmarks: 0,
       comments: 0,
-      recommender: { name: nick, avatar: "https://i.pravatar.cc/80?img=15", count: 1 },
+      recommender: { nick: nick, avatar: "https://i.pravatar.cc/80?img=15", count: 1 },
     };
     setItems((arr) => [newItem, ...arr]);
     setShowUpload(false);
@@ -154,7 +154,7 @@ export default function App() {
         <Route index element={<HomePage />} />
         <Route path="/me" element={<ProfilePage />} />
         <Route path="/me/bookshelf" element={<BookshelfPage />} />
-        <Route path="/u/:name" element={<UserProfilePage />} />
+        <Route path="/u/:nick" element={<UserProfilePage />} />
       </Route>
     </Routes>
   );

--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -21,13 +21,13 @@ export interface BookSummary {
   bookmarks?: number;
   comments?: number;
   createdAt?: string | number;
-  recommender?: { id: number; name: string; avatar?: string };
+  recommender?: { id: number; nick: string; avatar?: string };
 }
 
 export interface CommentItem {
   id: number;
   userId: number;
-  userName: string;
+  nick: string;
   userAvatar?: string;
   text: string;
   createdAt: string | number;
@@ -225,7 +225,7 @@ export interface NotificationItem {
   read: boolean;
   createdAt: string | number;
   /** 触发者 */
-  actor?: { id: number; name: string; avatar?: string };
+  actor?: { id: number; nick: string; avatar?: string };
   /** 关联书籍/评论 ID */
   bookId?: number;
   bookTitle?: string;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -19,14 +19,14 @@ export interface Book {
   bookmarks: number;
   comments: number;
   createdAt?: string; // 或 ISO
-  recommender?: { id: number; name: string; avatar?: string };
+  recommender?: { id: number; nick: string; avatar?: string };
 }
 
 // —— 评论
 export interface Comment {
   id: number;
   userId: number;
-  userName: string;
+  nick: string;
   userAvatar?: string;
   text: string;
   createdAt: string;
@@ -44,7 +44,7 @@ export interface Notification {
   content?: string;
   read: boolean;
   createdAt: string;
-  actor?: { id: number; name: string; avatar?: string };
+  actor?: { id: number; nick: string; avatar?: string };
   bookId?: number;
   bookTitle?: string;
   commentId?: number;

--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -102,17 +102,19 @@ export default function Leaderboard({ items = [], onOpenUser, fetcher }) {
         )}
 
         <div className="space-y-3">
-          {list.map((u, i) => (
-            <button
-              key={(u.name || u.nick || "u") + i}
-              onClick={() => onOpenUser && onOpenUser({ name: u.name, avatar: u.avatar })}
-              className="w-full text-left flex items-center gap-3 rounded-xl px-2 py-2 transition"
-              style={{
-                background: i < 3 ? "rgba(254,243,199,0.45)" : "#FFFFFF",
-                border: `1px solid ${THEME.border}`,
-              }}
-              type="button"
-            >
+          {list.map((u, i) => {
+            const displayNick = u.nick || u.name;
+            return (
+              <button
+                key={(displayNick || "u") + i}
+                onClick={() => onOpenUser && onOpenUser({ nick: displayNick, avatar: u.avatar })}
+                className="w-full text-left flex items-center gap-3 rounded-xl px-2 py-2 transition"
+                style={{
+                  background: i < 3 ? "rgba(254,243,199,0.45)" : "#FFFFFF",
+                  border: `1px solid ${THEME.border}`,
+                }}
+                type="button"
+              >
               {/* 序号徽章：前 3 名更醒目 */}
               <div
                 className="w-8 h-8 rounded-full flex items-center justify-center text-white text-sm"
@@ -131,11 +133,12 @@ export default function Leaderboard({ items = [], onOpenUser, fetcher }) {
                 {i + 1}
               </div>
 
-              <img src={u.avatar} className="w-8 h-8 rounded-full" alt={u.name} />
-              <div className="flex-1">{u.name}</div>
+              <img src={u.avatar} className="w-8 h-8 rounded-full" alt={displayNick} />
+              <div className="flex-1">{displayNick}</div>
               <div className="text-sm text-gray-600">{u.score}</div>
             </button>
-          ))}
+            );
+          })}
 
           {!remoteLoading && list.length === 0 && (
             <div className="text-sm text-gray-500 px-2">暂无数据</div>

--- a/src/components/NovelCard.jsx
+++ b/src/components/NovelCard.jsx
@@ -111,7 +111,7 @@ export default function NovelCard({
                 alt="avatar"
               />
               <span className="text-xs text-gray-700">
-                {item.recommender.name}
+                {item.recommender.nick}
               </span>
             </button>
           )}

--- a/src/components/modals/CommentsDrawer.jsx
+++ b/src/components/modals/CommentsDrawer.jsx
@@ -56,12 +56,12 @@ export default function CommentsDrawer({ open, onClose, item, list, onAdd, onLik
       >
         <img
           src={c.userAvatar || "/default-avatar.png"}
-          alt={c.userName}
+          alt={c.nick}
           className="w-7 h-7 rounded-full object-cover bg-gray-200"
         />
         <div className="flex-1">
           <div className="text-sm">
-            <span className="font-medium mr-2">{c.userName || "匿名用户"}</span>
+            <span className="font-medium mr-2">{c.nick || "匿名用户"}</span>
             <span className="text-gray-400">{formatDate(c.createdAt)}</span>
           </div>
           <div className="text-sm mt-0.5">{c.text}</div>

--- a/src/components/modals/NotificationsDrawer.jsx
+++ b/src/components/modals/NotificationsDrawer.jsx
@@ -126,7 +126,7 @@ export default function NotificationsDrawer({ open, onClose }) {
   };
 
   const renderText = (n) => {
-    const who = n.actor?.name || "有人";
+    const who = n.actor?.nick || "有人";
     const book = n.bookTitle || "作品";
     const excerpt = n.content || "";
     switch (n.type) {
@@ -281,7 +281,7 @@ export default function NotificationsDrawer({ open, onClose }) {
                   {n.actor?.avatar ? (
                     <img
                       src={n.actor.avatar}
-                      alt="avatar"
+                      alt={n.actor?.nick || "avatar"}
                       className="w-8 h-8 rounded-full"
                     />
                   ) : (

--- a/src/lib/mock.js
+++ b/src/lib/mock.js
@@ -28,7 +28,7 @@ export const BASE_ITEMS = [
     likes: 134,
     bookmarks: 56,
     comments: 3,
-    recommender: { name: "谷雨", avatar: "https://i.pravatar.cc/80?img=32", count: 3 },
+    recommender: { nick: "谷雨", avatar: "https://i.pravatar.cc/80?img=32", count: 3 },
   },
   {
     id: "seed-2",
@@ -43,7 +43,7 @@ export const BASE_ITEMS = [
     likes: 92,
     bookmarks: 35,
     comments: 2,
-    recommender: { name: "麦穗", avatar: "https://i.pravatar.cc/80?img=12", count: 4 },
+    recommender: { nick: "麦穗", avatar: "https://i.pravatar.cc/80?img=12", count: 4 },
   },
   {
     id: "seed-3",
@@ -58,7 +58,7 @@ export const BASE_ITEMS = [
     likes: 61,
     bookmarks: 40,
     comments: 1,
-    recommender: { name: "小仓鼠", avatar: "https://i.pravatar.cc/80?img=5", count: 1 },
+    recommender: { nick: "小仓鼠", avatar: "https://i.pravatar.cc/80?img=5", count: 1 },
   },
 ];
 
@@ -85,7 +85,7 @@ export function genMock(n = 18) {
       bookmarks: rint(0, 120),
       comments: rint(0, 50),
       recommender: {
-        name: ["谷雨","麦穗","小仓鼠","长夜灯","风栖"][rint(0, 4)],
+        nick: ["谷雨","麦穗","小仓鼠","长夜灯","风栖"][rint(0, 4)],
         avatar: `https://i.pravatar.cc/80?img=${rint(1, 60)}`,
         count: rint(1, 5),
       },
@@ -97,14 +97,14 @@ export function genMock(n = 18) {
 export const MOCK_ITEMS = [...BASE_ITEMS, ...genMock(18)];
 
 export const MOCK_LEADERS = [
-  { name: "谷雨", score: 981, avatar: "https://i.pravatar.cc/80?img=32" },
-  { name: "麦穗", score: 864, avatar: "https://i.pravatar.cc/80?img=12" },
-  { name: "小仓鼠", score: 733, avatar: "https://i.pravatar.cc/80?img=5" },
-  { name: "长夜灯", score: 512, avatar: "https://i.pravatar.cc/80?img=14" },
-  { name: "风栖", score: 401, avatar: "https://i.pravatar.cc/80?img=23" },
-  { name: "白梅", score: 355, avatar: "https://i.pravatar.cc/80?img=37" },
-  { name: "清岚", score: 322, avatar: "https://i.pravatar.cc/80?img=21" },
-  { name: "拾荒人", score: 305, avatar: "https://i.pravatar.cc/80?img=44" },
-  { name: "芒果冰", score: 292, avatar: "https://i.pravatar.cc/80?img=9" },
-  { name: "溪水", score: 280, avatar: "https://i.pravatar.cc/80?img=28" },
+  { nick: "谷雨", score: 981, avatar: "https://i.pravatar.cc/80?img=32" },
+  { nick: "麦穗", score: 864, avatar: "https://i.pravatar.cc/80?img=12" },
+  { nick: "小仓鼠", score: 733, avatar: "https://i.pravatar.cc/80?img=5" },
+  { nick: "长夜灯", score: 512, avatar: "https://i.pravatar.cc/80?img=14" },
+  { nick: "风栖", score: 401, avatar: "https://i.pravatar.cc/80?img=23" },
+  { nick: "白梅", score: 355, avatar: "https://i.pravatar.cc/80?img=37" },
+  { nick: "清岚", score: 322, avatar: "https://i.pravatar.cc/80?img=21" },
+  { nick: "拾荒人", score: 305, avatar: "https://i.pravatar.cc/80?img=44" },
+  { nick: "芒果冰", score: 292, avatar: "https://i.pravatar.cc/80?img=9" },
+  { nick: "溪水", score: 280, avatar: "https://i.pravatar.cc/80?img=28" },
 ];

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -55,17 +55,17 @@ export const aggregateUserHeat = (items = [], mode = "champion", days = 30) => {
       ? Date.now() - days * 24 * 3600 * 1000
       : Number.NEGATIVE_INFINITY;
 
-  const map = new Map(); // name -> { name, avatar, score }
+  const map = new Map(); // nick -> { nick, avatar, score }
 
   for (const it of items) {
-    if (!it?.recommender?.name) continue;
+    if (!it?.recommender?.nick) continue;
     const when = new Date(it.createdAt).getTime();
     if (when < since) continue;
 
-    const key = it.recommender.name;
+    const key = it.recommender.nick;
     const add = heatScore(it);
     if (!map.has(key)) {
-      map.set(key, { name: key, avatar: it.recommender.avatar, score: 0 });
+      map.set(key, { nick: key, avatar: it.recommender.avatar, score: 0 });
     }
     map.get(key).score += add;
   }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -166,7 +166,7 @@ export default function HomePage() {
                   onToggleSave={() => handleToggleSave(item)} // 再次点击即取消
                   onOpenDetail={() => nav(`/book/${encodeURIComponent(item.id)}`)}
                   onOpenComments={() => setCommentsOpen({ open: true, item })}
-                  onOpenUser={(u) => nav(`/u/${encodeURIComponent(u.name)}`)}
+                  onOpenUser={(u) => nav(`/u/${encodeURIComponent(u.nick)}`)}
                 />
               ))}
             </div>
@@ -177,7 +177,7 @@ export default function HomePage() {
         <div className="lg:col-span-3 space-y-4">
           <Leaderboard
             items={viewItems}
-            onOpenUser={(u) => nav(`/u/${encodeURIComponent(u.name)}`)}
+            onOpenUser={(u) => nav(`/u/${encodeURIComponent(u.nick)}`)}
           />
         </div>
       </main>

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -96,7 +96,7 @@ export function BookshelfSection() {
   const [tab, setTab] = useState("fav"); // fav | rec | sheet
 
   const favorites = items.filter((i) => savedIds.has(i.id));
-  const myRecs = items.filter((i) => i?.recommender?.name === nick);
+  const myRecs = items.filter((i) => i?.recommender?.nick === nick);
 
   const list = tab === "fav" ? favorites : myRecs;
 

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -5,20 +5,20 @@ import NovelCard from "../components/NovelCard";
 import { useAppStore } from "../store/AppStore";
 
 export default function UserProfilePage() {
-  const { name } = useParams();
-  const displayName = decodeURIComponent(name || "");
+  const { nick } = useParams();
+  const displayNick = decodeURIComponent(nick || "");
   const { items } = useAppStore();
 
   // 从后端列表中过滤出 TA 推荐的书
   const recs = (items || []).filter(
-    (i) => i?.recommender?.name === displayName
+    (i) => i?.recommender?.nick === displayNick
   );
 
   // 头像：优先用书卡里 recommender.avatar（若能命中），否则占位
   const avatarFromBooks =
     recs.find((i) => i?.recommender?.avatar)?.recommender?.avatar || null;
   const user = {
-    name: displayName,
+    nick: displayNick,
     avatar: avatarFromBooks || "https://i.pravatar.cc/80?img=24",
   };
 
@@ -27,7 +27,7 @@ export default function UserProfilePage() {
       <div className="flex items-center gap-4">
         <img src={user.avatar} className="w-20 h-20 rounded-full" />
         <div>
-          <div className="text-xl font-semibold">{user.name}</div>
+          <div className="text-xl font-semibold">{user.nick}</div>
           <div className="text-gray-500 text-sm">仅展示：头像、昵称、TA推荐的书</div>
         </div>
       </div>

--- a/src/store/AppStore.jsx
+++ b/src/store/AppStore.jsx
@@ -431,7 +431,7 @@ export function AppProvider({ children }) {
         c?.data ||
         c || {
           id: Date.now(),
-          userName: nick,
+          nick,
           userAvatar: avatar || "https://i.pravatar.cc/80?img=15",
           text,
           createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Show `nick` for commenters instead of usernames
- Replace recommender and profile routing to use `nick`
- Update notifications and API types to expose `nick` fields

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1261abfdc833188c6d82e3a0eae19