### PR TITLE
fix: ensure publish creates book and support avatar file uploads

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -48,12 +48,24 @@ export const authApi = {
 // --------------- Me ----------------------
 export const meApi = {
   get: () => http.get<User>('/api/me'),
-  patch: (payload: { nickname?: string; avatar?: string }) =>
+  patch: (payload: { nickname?: string; avatar?: string; avatarUrl?: string }) =>
     http.patch<User>('/api/me', payload),
   checkNickname: (nickname: string) =>
     http.get<{ exists: boolean }>('/api/users/check-nickname', {
       params: { nickname },
     }),
+};
+
+// --------------- Uploads -----------------
+export const uploadApi = {
+  /** 上传头像文件，返回 URL */
+  avatar: (file: File) => {
+    const fd = new FormData();
+    fd.append('file', file);
+    return http.post<{ url: string }>('/api/uploads/avatar', fd, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+  },
 };
 
 // --------------- Books -------------------

--- a/src/env.development
+++ b/src/env.development
@@ -1,2 +1,3 @@
 # 根目录或 frontend 根目录下 .env.development
 VITE_API_BASE=http://localhost:8080
+VITE_AVATAR_USE_FILE=false

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE: string; // 例如 http://localhost:8080
+  readonly VITE_AVATAR_USE_FILE?: string; // 是否启用文件上传头像
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- always create book after duplicate check to fix publish not submitting
- add avatar upload flow with file support and feature flag fallback
- overlay progress, retryable patch and env config for avatar uploads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a12e83f4908331ae1e5ff8bea3a619