### PR TITLE
Fix avatar upload and book creation

### DIFF
--- a/src/components/modals/UploadDrawer.jsx
+++ b/src/components/modals/UploadDrawer.jsx
@@ -212,7 +212,7 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
       console.warn("check book duplicate failed", e);
     }
 
-    const payload = { title, author, tags, raw, orientation, category, blurb, summary };
+    const payload = { title, author, tags, orientation, category, blurb, summary };
 
     // 若父层提供 onSubmit，可先执行（用于本地插卡等），无论结果如何都继续真实落库
     if (onSubmit) {

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -164,8 +164,6 @@ export default function ProfilePage() {
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState(false);
   const fileRef = useRef(null);
-  const USE_FILE = import.meta.env.VITE_AVATAR_USE_FILE === 'true';
-  const [pendingUrl, setPendingUrl] = useState(null);
   const displayAvatar = avatar || "https://i.pravatar.cc/120?img=15";
 
   // 配置：昵称长度限制
@@ -200,14 +198,12 @@ export default function ProfilePage() {
         return;
       }
 
-      // 3) 保存（若有未提交的头像 URL 一并提交）
-      const payload = pendingUrl ? { nickname: trimmed, avatarUrl: pendingUrl } : { nickname: trimmed };
-      const r = await meApi.patch(payload);
+      // 3) 保存
+      const r = await meApi.patch({ nickname: trimmed });
       const d = r?.data ?? r ?? {};
       setNick(d.nick ?? trimmed);
       setUser((u) => (u ? { ...u, nick: d.nick ?? trimmed } : u));
       setToast("保存成功");
-      if (pendingUrl) setPendingUrl(null);
     } catch (e) {
       console.error("update nickname failed", e);
       setToast("保存失败");
@@ -221,63 +217,33 @@ export default function ProfilePage() {
   const handleAvatar = async (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    if (!/(image\/jpeg|image\/png|image\/webp)/.test(file.type)) {
-      setToast("仅支持 JPG/PNG/WEBP 格式");
+    if (!/(image\/jpeg|image\/png)/.test(file.type)) {
+      setToast("仅支持 JPG/PNG 格式");
       return;
     }
     if (file.size > 2 * 1024 * 1024) {
       setToast("图片过大，请压缩后再试（≤2MB）");
       return;
     }
-
-    if (USE_FILE) {
-      try {
-        setUploading(true);
-        const res = await uploadApi.avatar(file);
-        const url = res?.data?.url ?? res?.url;
-        if (!url) throw new Error('no url');
-        const tsUrl = `${url}?t=${Date.now()}`;
-        setAvatar(tsUrl);
-        setUser((u) => (u ? { ...u, avatar: tsUrl } : u));
-        setPendingUrl(url);
-        try {
-          await meApi.patch({ avatarUrl: url });
-          setPendingUrl(null);
-          setToast("上传成功");
-        } catch (err) {
-          console.error("patch avatar failed", err);
-          setToast("资料更新失败");
-        }
-      } catch (err) {
-        console.error("upload avatar failed", err);
-        const status = err?.response?.status;
-        if (status === 413) setToast("图片过大");
-        else if (status === 415) setToast("类型不支持");
-        else if (status === 400) setToast(err?.response?.data?.message || "校验失败");
-        else setToast("上传失败，请稍后重试");
-      } finally {
-        setUploading(false);
-      }
-    } else {
-      const reader = new FileReader();
-      reader.onload = async () => {
-        try {
-          setUploading(true);
-          const base64 = reader.result;
-          const r = await meApi.patch({ avatar: base64 });
-          const d = r?.data ?? r ?? {};
-          const newAvatar = d.avatar ?? base64;
-          setAvatar(newAvatar);
-          setUser((u) => (u ? { ...u, avatar: newAvatar } : u));
-          setToast("上传成功");
-        } catch (err) {
-          console.error("upload avatar failed", err);
-          setToast("上传失败，请稍后重试");
-        } finally {
-          setUploading(false);
-        }
-      };
-      reader.readAsDataURL(file);
+    try {
+      setUploading(true);
+      const res = await uploadApi.avatar(file);
+      const url = res?.data?.url ?? res?.url;
+      if (!url) throw new Error('no url');
+      const tsUrl = `${url}?t=${Date.now()}`;
+      setAvatar(tsUrl);
+      setUser((u) => (u ? { ...u, avatar: tsUrl } : u));
+      await meApi.patch({ avatarUrl: url });
+      setToast("上传成功");
+    } catch (err) {
+      console.error("upload avatar failed", err);
+      const status = err?.response?.status;
+      if (status === 413) setToast("图片过大");
+      else if (status === 415) setToast("类型不支持");
+      else if (status === 400) setToast(err?.response?.data?.message || "校验失败");
+      else setToast("上传失败，请稍后重试");
+    } finally {
+      setUploading(false);
     }
   };
 


### PR DESCRIPTION
## Summary
- Ensure profile avatar uploads to `/api/uploads/avatar` and updates the user record
- Remove undefined `raw` field that prevented book creation after duplicate check

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a135a617a88331bb023316701dd0c2