### PR TITLE
fix: show recommender avatar and name

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,7 +68,12 @@ function Shell() {
       likes: 0,
       bookmarks: 0,
       comments: 0,
-      recommender: { nick: nick, avatar: "https://i.pravatar.cc/80?img=15", count: 1 },
+      recommender: {
+        name: nick,
+        nick: nick,
+        avatar: "https://i.pravatar.cc/80?img=15",
+        count: 1,
+      },
     };
     setItems((arr) => [newItem, ...arr]);
     setShowUpload(false);

--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -4,6 +4,7 @@ import http from './http';
 // ---------------- 公共类型 ----------------
 export interface User {
   id: number;
+  name?: string;
   nick?: string;
   nickname?: string;
   avatar: string;
@@ -22,13 +23,20 @@ export interface BookSummary {
   bookmarks?: number;
   comments?: number;
   createdAt?: string | number;
-  recommender?: { id: number; nick?: string; nickname?: string; avatar?: string };
+  recommender?: {
+    id: number;
+    name?: string;
+    nick?: string;
+    nickname?: string;
+    avatar?: string;
+  };
 }
 
 export interface CommentItem {
   id: number;
   userId: number;
-  nick: string;
+  nick?: string;
+  name?: string;
   userAvatar?: string;
   text: string;
   createdAt: string | number;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -19,14 +19,21 @@ export interface Book {
   bookmarks: number;
   comments: number;
   createdAt?: string; // 或 ISO
-  recommender?: { id: number; nick?: string; nickname?: string; avatar?: string };
+  recommender?: {
+    id: number;
+    name?: string;
+    nick?: string;
+    nickname?: string;
+    avatar?: string;
+  };
 }
 
 // —— 评论
 export interface Comment {
   id: number;
   userId: number;
-  nick: string;
+  nick?: string;
+  name?: string;
   userAvatar?: string;
   text: string;
   createdAt: string;
@@ -44,7 +51,7 @@ export interface Notification {
   content?: string;
   read: boolean;
   createdAt: string;
-  actor?: { id: number; nick: string; avatar?: string };
+  actor?: { id: number; nick?: string; name?: string; avatar?: string };
   bookId?: number;
   bookTitle?: string;
   commentId?: number;

--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -103,7 +103,7 @@ export default function Leaderboard({ items = [], onOpenUser, fetcher }) {
 
         <div className="space-y-3">
           {list.map((u, i) => {
-            const displayNick = u.nick || u.name;
+            const displayNick = u.name || u.nick;
             return (
               <button
                 key={(displayNick || "u") + i}

--- a/src/components/NovelCard.jsx
+++ b/src/components/NovelCard.jsx
@@ -101,7 +101,7 @@ export default function NovelCard({
           </span>
           {(() => {
             const rec = item?.recommender;
-            const recNick = rec?.nick || rec?.nickname;
+            const recNick = rec?.name || rec?.nick || rec?.nickname;
             if (!rec || !recNick) return null;
             return (
               <button
@@ -114,7 +114,7 @@ export default function NovelCard({
                 <img
                   src={rec.avatar}
                   className="w-6 h-6 rounded-full ring-2 ring-white"
-                  alt="avatar"
+                  alt={recNick}
                 />
                 <span className="text-xs text-gray-700">{recNick}</span>
               </button>

--- a/src/components/modals/CommentsDrawer.jsx
+++ b/src/components/modals/CommentsDrawer.jsx
@@ -56,12 +56,12 @@ export default function CommentsDrawer({ open, onClose, item, list, onAdd, onLik
       >
         <img
           src={c.userAvatar || "/default-avatar.png"}
-          alt={c.nick}
+          alt={c.nick || c.name || "avatar"}
           className="w-7 h-7 rounded-full object-cover bg-gray-200"
         />
         <div className="flex-1">
           <div className="text-sm">
-            <span className="font-medium mr-2">{c.nick || "匿名用户"}</span>
+            <span className="font-medium mr-2">{c.nick || c.name || "匿名用户"}</span>
             <span className="text-gray-400">{formatDate(c.createdAt)}</span>
           </div>
           <div className="text-sm mt-0.5">{c.text}</div>

--- a/src/components/modals/NotificationsDrawer.jsx
+++ b/src/components/modals/NotificationsDrawer.jsx
@@ -126,7 +126,7 @@ export default function NotificationsDrawer({ open, onClose }) {
   };
 
   const renderText = (n) => {
-    const who = n.actor?.nick || "有人";
+    const who = n.actor?.nick || n.actor?.name || "有人";
     const book = n.bookTitle || "作品";
     const excerpt = n.content || "";
     switch (n.type) {
@@ -281,7 +281,7 @@ export default function NotificationsDrawer({ open, onClose }) {
                   {n.actor?.avatar ? (
                     <img
                       src={n.actor.avatar}
-                      alt={n.actor?.nick || "avatar"}
+                      alt={n.actor?.nick || n.actor?.name || "avatar"}
                       className="w-8 h-8 rounded-full"
                     />
                   ) : (

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -59,7 +59,7 @@ export const aggregateUserHeat = (items = [], mode = "champion", days = 30) => {
 
   for (const it of items) {
     const r = it?.recommender;
-    const nick = r?.nick || r?.nickname;
+    const nick = r?.name || r?.nick || r?.nickname;
     if (!nick) continue;
     const when = new Date(it.createdAt).getTime();
     if (when < since) continue;

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -98,7 +98,7 @@ export function BookshelfSection() {
   const favorites = items.filter((i) => savedIds.has(i.id));
   const myRecs = items.filter((i) => {
     const r = i?.recommender;
-    const recNick = r?.nick || r?.nickname;
+    const recNick = r?.name || r?.nick || r?.nickname;
     return recNick === nick;
   });
 
@@ -205,8 +205,8 @@ export default function ProfilePage() {
       // 3) 保存
       const r = await meApi.patch({ nickname: trimmed });
       const d = r?.data ?? r ?? {};
-      setNick(d.nick ?? trimmed);
-      setUser((u) => (u ? { ...u, nick: d.nick ?? trimmed } : u));
+      setNick(d.nick ?? d.name ?? trimmed);
+      setUser((u) => (u ? { ...u, nick: d.nick ?? d.name ?? trimmed } : u));
       setToast("保存成功");
     } catch (e) {
       console.error("update nickname failed", e);

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -12,7 +12,7 @@ export default function UserProfilePage() {
   // 从后端列表中过滤出 TA 推荐的书
   const recs = (items || []).filter((i) => {
     const r = i?.recommender;
-    const nick = r?.nick || r?.nickname;
+    const nick = r?.name || r?.nick || r?.nickname;
     return nick === displayNick;
   });
 

--- a/src/store/AppStore.jsx
+++ b/src/store/AppStore.jsx
@@ -112,7 +112,7 @@ export function AppProvider({ children }) {
       const u = d.user || {};
       const mapped = {
         id: u.id ?? 1,
-        nick: u.nick ?? nick ?? "新用户",
+        nick: u.nick ?? u.name ?? u.nickname ?? nick ?? "新用户",
         avatar: u.avatar ?? "https://i.pravatar.cc/80?img=15",
       };
       setUser(mapped);
@@ -545,7 +545,7 @@ export function AppProvider({ children }) {
     if (cached) {
       try {
         const u = JSON.parse(cached);
-        if (u.nick) setNick(u.nick);
+        if (u.nick || u.name || u.nickname) setNick(u.nick || u.name || u.nickname);
         if (u.avatar) setAvatar(u.avatar);
         setUser(u);
       } catch {}
@@ -556,12 +556,12 @@ export function AppProvider({ children }) {
         const r = await meApi.get();
         const d = r?.data || r || {};
         if (!mounted) return;
-        if (d.nick) setNick(d.nick);
+        if (d.nick || d.name || d.nickname) setNick(d.nick || d.name || d.nickname);
         if (d.avatar) setAvatar(d.avatar);
         if (d.id)
           setUser({
             id: d.id,
-            nick: d.nick ?? nick,
+            nick: d.nick ?? d.name ?? d.nickname ?? nick,
             avatar: d.avatar ?? avatar,
             phone: d.phone,
           });


### PR DESCRIPTION
## Summary
- display recommender nickname and avatar on NovelCard using new `name` field
- make user pages and utilities accept recommender `name` when filtering/aggregating
- broaden API types and comments/notifications to read either `name` or `nick`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a13bd2a57c8331b85ae35a60045919