### PR TITLE
fix: restore comment posting and tidy UI mapping

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,10 +84,14 @@ function Shell() {
   };
 
   const currentBookId = commentsOpen?.item?.id;
-  const commentList = currentBookId ? commentsMap[currentBookId] || [] : [];
+  // 使用数字键读取，避免字符串/数字混用导致取不到缓存的评论
+  const commentList = currentBookId
+    ? commentsMap[Number(currentBookId)] || []
+    : [];
 
   // ✅ 关键修复：发表评论后，除更新本地 commentsMap 外，失效刷新首页/榜单，让评论数立刻 +1
   const handleAddComment = async (text, parentId) => {
+    if (typeof addComment !== "function") return;
     await addComment(text, parentId); // 调后端并更新 commentsMap
     qc.invalidateQueries({ queryKey: ["books"] });
     qc.invalidateQueries({ queryKey: ["leaderboard"] });

--- a/src/components/ui/BookListRow.jsx
+++ b/src/components/ui/BookListRow.jsx
@@ -40,8 +40,9 @@ export default function BookListRow({ book = {}, onEdit, onDelete, onMove }) {
     author,
     orientation,
     category,
-    rating: rating === "" ? undefined : rating,
-    review: oneLine || book.review,
+      rating: rating === "" ? undefined : rating,
+      // oneLine 已包含各种字段兼容，这里直接复用避免字段重复
+      review: oneLine,
   };
 
   const [detailOpen, setDetailOpen] = useState(false);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,7 +9,11 @@ import "./index.css";
 // 关键：用命名空间导入，自动兼容不同导出名
 import * as AppStore from "./store/AppStore";
 // 优先使用 AppProvider，其次 AppStoreProvider；都没有就用 Fragment 兜底
-const StoreProvider = AppStore.AppProvider || AppStore.AppStoreProvider || React.Fragment;
+let StoreProvider = AppStore.AppProvider;
+if (!StoreProvider && "AppStoreProvider" in AppStore) {
+  StoreProvider = AppStore["AppStoreProvider"];
+}
+if (!StoreProvider) StoreProvider = React.Fragment;
 
 const qc = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## Summary
- ensure comments drawer pulls current book comments and safely calls addComment
- reuse normalized one-line review in BookListRow to avoid inconsistent data
- allow main entry to gracefully fall back to available store provider export

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a155e56bf88331a9fd21d7506f1b79