### PR TITLE
fix: include userId for book updates

### DIFF
--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -82,11 +82,11 @@ export const useCreateBook = () => {
 };
 
 // 覆盖更新
-export const useUpdateBook = (id?: number) => {
+export const useUpdateBook = (id?: number, userId?: number) => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (payload: Parameters<typeof bookApi.update>[1]) =>
-      bookApi.update(id as number, payload),
+    mutationFn: (payload: Parameters<typeof bookApi.update>[2]) =>
+      bookApi.update(id as number, userId as number, payload),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['book', id] });
       qc.invalidateQueries({ queryKey: ['books'] });

--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -111,8 +111,11 @@ export const bookApi = {
   checkExist: (payload: { title: string; author?: string }) =>
     http.get<{ exists: boolean }>('/api/books/check', { params: payload }),
 
-  update: (id: number, payload: Partial<Omit<BookSummary, 'id'>>) =>
-    http.put<BookSummary>(`/api/books/${id}`, payload),
+  update: (
+    id: number,
+    userId: number,
+    payload: Partial<Omit<BookSummary, 'id'>>,
+  ) => http.put<BookSummary>(`/api/books/${id}`, payload, { params: { userId } }),
 
   patch: (id: number, payload: Partial<Omit<BookSummary, 'id'>>) =>
     http.patch<BookSummary>(`/api/books/${id}`, payload),

--- a/src/components/modals/EditBookDrawer.jsx
+++ b/src/components/modals/EditBookDrawer.jsx
@@ -97,7 +97,7 @@ export default function EditBookDrawer({ open, bookId, onClose }) {
   const [expired, setExpired] = useState(false);
 
   const { user } = useAppStore();
-  const updateBook = useUpdateBook(bookId);
+  const updateBook = useUpdateBook(bookId, user?.id);
 
   const allBaseTags = useMemo(() => Array.from(new Set(TAGS)), []);
   const [remoteSuggest, setRemoteSuggest] = useState([]);


### PR DESCRIPTION
## Summary
- include `userId` as a query parameter for book updates
- allow `useUpdateBook` to send `userId`
- pass current user id when editing a book

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2293ec5a48326ae0156796ca252b9