### PR TITLE
feat: improve responsive layout

### DIFF
--- a/src/components/NovelCard.jsx
+++ b/src/components/NovelCard.jsx
@@ -151,22 +151,22 @@ export default function NovelCard({
           )}
         </div>
 
-        <div className="p-4 h-full flex flex-col relative">
+        <div className="p-4 sm:p-5 h-full flex flex-col relative">
           <div className="flex-1">
-            <div className="flex items-center gap-2 pr-28">
+            <div className="flex items-center gap-2 pr-16 sm:pr-28">
               <OriChip value={item?.orientation || "其他"} />
               <Chip bg="#FFF" text="#6B7280">
                 {item?.category || "其他"}
               </Chip>
             </div>
-            <div className="mt-1 text-xs text-gray-500">
+            <div className="mt-1 text-xs sm:text-sm text-gray-500">
               推荐时间：{createdAt}
             </div>
 
             <div className="mt-1 flex items-center gap-2">
               <button
                 onClick={() => onOpenDetail && onOpenDetail(item)}
-                className="text-[16px] font-semibold hover:underline"
+                className="text-base sm:text-lg font-semibold hover:underline"
                 title="查看详情"
                 style={{ color: "#374151" }}
               >
@@ -175,7 +175,7 @@ export default function NovelCard({
               <span className="text-sm text-gray-500">作者：{author}</span>
               <button
                 onClick={openSummary}
-                className="ml-auto inline-flex items-center gap-1 text-xs px-2 py-1 rounded-full border"
+                className="ml-auto inline-flex items-center gap-1 text-xs sm:text-sm px-2 py-1 rounded-full border"
                 style={{
                   borderColor: THEME.border,
                   background: THEME.surface,
@@ -200,18 +200,18 @@ export default function NovelCard({
             </div>
 
             <div
-              className="mt-3 text-[15px] leading-relaxed text-gray-700 overflow-hidden"
+              className="mt-3 text-sm sm:text-base leading-relaxed text-gray-700 overflow-hidden"
               style={{ minHeight: 48 }}
             >
               {item?.blurb || "——"}
             </div>
           </div>
 
-          <div className="mt-4 flex items-center gap-3">
+          <div className="mt-4 flex items-center gap-2 sm:gap-3">
             <motion.button
               whileTap={{ scale: 0.9 }}
               onClick={onLike}
-              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full border"
+              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full border text-sm"
               style={{
                 borderColor: THEME.border,
                 background: liked ? "#FFF1F3" : THEME.surface,
@@ -228,7 +228,7 @@ export default function NovelCard({
             <motion.button
               whileTap={{ scale: 0.95 }}
               onClick={onToggleSave}
-              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full border"
+              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full border text-sm"
               style={{
                 borderColor: THEME.border,
                 background: saved ? "#F5F3FF" : THEME.surface,
@@ -244,7 +244,7 @@ export default function NovelCard({
 
             <button
               onClick={onOpenComments}
-              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full border"
+              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full border text-sm"
               style={{ borderColor: THEME.border, background: THEME.surface }}
               title="评论"
             >

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -20,6 +20,9 @@ export default function HomePage() {
   const likePending = React.useRef(new Set());
   const bookmarkPending = React.useRef(new Set());
 
+  // 小屏下排行榜折叠开关
+  const [showLeaderboard, setShowLeaderboard] = React.useState(false);
+
   const {
     // 我已点赞/收藏（用于高亮 & 判断增减）
     likedIds, toggleLike,
@@ -156,7 +159,7 @@ export default function HomePage() {
               或检查来源数据是否缺少必填字段（title/category/orientation）。
             </div>
           ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
               {viewItems.map((item) => (
                 <NovelCard
                   key={item.id || item.title}
@@ -179,8 +182,8 @@ export default function HomePage() {
           )}
         </div>
 
-        {/* 右侧：排行榜（Top 10） */}
-        <div className="lg:col-span-3 space-y-4">
+        {/* 右侧：排行榜（Top 10）桌面端显示 */}
+        <div className="hidden lg:block lg:col-span-3 space-y-4">
           <Leaderboard
             items={viewItems}
             onOpenUser={(u) =>
@@ -191,6 +194,30 @@ export default function HomePage() {
           />
         </div>
       </main>
+
+      {/* 小屏：折叠排行榜移动到底部 */}
+      <div className="lg:hidden max-w-[1200px] mx-auto px-4 mt-6">
+        <button
+          onClick={() => setShowLeaderboard((v) => !v)}
+          className="w-full flex items-center justify-between px-4 py-2 rounded-lg border text-sm"
+          style={{ borderColor: THEME.border, background: THEME.surface }}
+        >
+          <span>排行榜</span>
+          <span>{showLeaderboard ? "收起" : "展开"}</span>
+        </button>
+        {showLeaderboard && (
+          <div className="mt-4 space-y-4">
+            <Leaderboard
+              items={viewItems}
+              onOpenUser={(u) =>
+                nav(`/u/${encodeURIComponent(u.nick)}`, {
+                  state: { avatar: u.avatar },
+                })
+              }
+            />
+          </div>
+        )}
+      </div>
 
       <div className="text-center text-xs text-gray-500 py-8">
         <span style={{ color: THEME.orchid }}>

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -106,7 +106,7 @@ export function BookshelfSection() {
 
   return (
     <div className="mt-6">
-      <div className="flex gap-2 mb-4">
+      <div className="flex flex-wrap gap-2 mb-4">
         <button
           onClick={() => setTab("fav")}
           className={classNames(
@@ -142,7 +142,7 @@ export function BookshelfSection() {
       {tab === "sheet" ? (
         <BookSheetPanel />
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {list.map((item) => (
             <NovelCard
               key={item.id}
@@ -257,7 +257,7 @@ export default function ProfilePage() {
       <Toast message={toast} onClose={() => setToast("")} />
 
       {/* 顶部：头像 + 昵称 */}
-      <div className="flex items-center gap-4">
+      <div className="flex flex-col sm:flex-row items-center gap-4">
         <div className="relative">
           <img src={displayAvatar} className="w-20 h-20 rounded-full object-cover" />
           {uploading && (
@@ -282,7 +282,7 @@ export default function ProfilePage() {
             onChange={handleAvatar}
           />
         </div>
-        <div>
+        <div className="text-center sm:text-left">
           <div className="text-xl font-semibold">{nick}</div>
           <div className="text-gray-500 text-sm">我的主页</div>
         </div>

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -29,16 +29,16 @@ export default function UserProfilePage() {
 
   return (
     <div className="max-w-[1100px] mx-auto px-4 py-6">
-      <div className="flex items-center gap-4">
+      <div className="flex flex-col sm:flex-row items-center gap-4">
         <img src={user.avatar} className="w-20 h-20 rounded-full" />
-        <div>
+        <div className="text-center sm:text-left">
           <div className="text-xl font-semibold">{user.nick}</div>
           <div className="text-gray-500 text-sm">仅展示：头像、昵称、TA推荐的书</div>
         </div>
       </div>
 
       <div className="mt-6 text-lg font-semibold">TA推荐的书（{recs.length}）</div>
-      <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {recs.map((item) => (
           <NovelCard
             key={item.id}


### PR DESCRIPTION
## Summary
- make home page grids responsive and collapsible leaderboard for small screens
- adjust NovelCard for better readability on phones and tablets
- add responsive breakpoints to profile related pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a270f4b8d483269ec420f007dc4ec8