### PR TITLE
fix: improve mobile drawer overlays

### DIFF
--- a/src/components/modals/MobileMenuDrawer.jsx
+++ b/src/components/modals/MobileMenuDrawer.jsx
@@ -1,6 +1,7 @@
 // src/components/modals/MobileMenuDrawer.jsx
 import React, { useEffect, useRef } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
 import { Upload, Bell, LogIn, User2, X } from "lucide-react";
 import { THEME } from "../../lib/theme";
 import { useAppStore } from "../../store/AppStore";
@@ -13,6 +14,8 @@ export default function MobileMenuDrawer({ open, onClose, onOpenUpload }) {
 
   useEffect(() => {
     if (!open) return;
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
     const onKey = (e) => e.key === "Escape" && onClose?.();
     const onDown = (e) => {
       if (ref.current && !ref.current.contains(e.target)) {
@@ -24,6 +27,7 @@ export default function MobileMenuDrawer({ open, onClose, onOpenUpload }) {
     return () => {
       document.removeEventListener("keydown", onKey);
       document.removeEventListener("mousedown", onDown);
+      document.body.style.overflow = originalOverflow;
     };
   }, [open, onClose]);
 
@@ -65,19 +69,19 @@ export default function MobileMenuDrawer({ open, onClose, onOpenUpload }) {
     </button>
   );
 
-  return (
+  const body = (
     <AnimatePresence>
       {open && (
         <>
           <motion.div
-            className="fixed inset-0 bg-black/30 z-40"
+            className="fixed inset-0 bg-black/30 z-[1000]"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
           />
           <motion.div
             ref={ref}
-            className="fixed top-0 right-0 h-full w-64 bg-white z-50 flex flex-col shadow-lg"
+            className="fixed top-0 right-0 h-full w-64 bg-white z-[1001] flex flex-col shadow-lg"
             initial={{ x: "100%" }}
             animate={{ x: 0 }}
             exit={{ x: "100%" }}
@@ -108,5 +112,7 @@ export default function MobileMenuDrawer({ open, onClose, onOpenUpload }) {
       )}
     </AnimatePresence>
   );
+
+  return createPortal(body, document.body);
 }
 

--- a/src/components/modals/UploadDrawer.jsx
+++ b/src/components/modals/UploadDrawer.jsx
@@ -1,6 +1,7 @@
 // src/components/modals/UploadDrawer.jsx
 import React, { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { createPortal } from "react-dom";
 import { Upload, PlusCircle, X } from "lucide-react";
 import { ORIENTATIONS, CATEGORIES, TAGS } from "../../lib/constants";
 import { THEME } from "../../lib/theme";
@@ -118,6 +119,15 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
     return () => clearTimeout(handle);
   }, [tagInput]);
 
+  useEffect(() => {
+    if (!open) return;
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [open]);
+
   const suggestions = useMemo(() => {
     const q = tagInput.trim().toLowerCase();
     if (!q) return [];
@@ -234,11 +244,11 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
     }
   };
 
-  return (
+  const body = (
     <AnimatePresence>
       {open && (
         <motion.div
-          className="fixed inset-0 z-50"
+          className="fixed inset-0 z-[1000]"
           style={{ background: "rgba(20,16,21,0.35)" }}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -470,4 +480,6 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
       )}
     </AnimatePresence>
   );
+
+  return createPortal(body, document.body);
 }


### PR DESCRIPTION
## Summary
- render MobileMenuDrawer via portal and lock body scroll
- port UploadDrawer to portal with scroll lock for consistent overlays

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a273a566d083268ec6c9e656dc0893