### PR TITLE
Fix desktop layout and hide FAB during edits

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,6 +45,7 @@ function Shell() {
     setEditingBook,
     setPage,
     user,
+    fabHidden,
   } = useAppStore();
 
   // 发布上传（保持原有本地插卡行为；UploadDrawer 里也已接上后端，二者兼容）
@@ -107,8 +108,8 @@ function Shell() {
       <Outlet />
       <Footer />
 
-      {/* 右下角悬浮 + 按钮：当评论抽屉打开时隐藏，避免遮挡输入框 */}
-      {!commentsOpen.open && (
+      {/* 右下角悬浮 + 按钮：编辑/评论/上传时隐藏，避免遮挡输入 */}
+      {!(commentsOpen.open || showUpload || editingBook || fabHidden) && (
         <button
           onClick={() => (user ? setShowUpload(true) : setAuthOpen(true))}
           title="闪电上传"

--- a/src/components/BookSheetPanel.jsx
+++ b/src/components/BookSheetPanel.jsx
@@ -1,5 +1,5 @@
 // src/components/BookSheetPanel.jsx
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import { useAppStore } from "../store/AppStore";
 import { THEME } from "../lib/theme";
 import { classNames, formatDate } from "../lib/utils";
@@ -33,6 +33,7 @@ export default function BookSheetPanel() {
     updateBookInSheet,
     removeBookFromSheet,
     moveBookToSheet,
+    setFabHidden,
   } = useAppStore();
 
   // 当前激活书单
@@ -63,6 +64,27 @@ export default function BookSheetPanel() {
   const [editingBook, setEditingBook] = useState(null);
   const [moveModalOpen, setMoveModalOpen] = useState(false);
   const [movingBook, setMovingBook] = useState(null);
+
+  // 打开任意编辑弹层时隐藏右下角 + 按钮
+  useEffect(() => {
+    setFabHidden(
+      listFormOpen ||
+        bookFormOpen ||
+        moveModalOpen ||
+        confirmOpen ||
+        !!editingSheet ||
+        !!editingBook
+    );
+    return () => setFabHidden(false);
+  }, [
+    listFormOpen,
+    bookFormOpen,
+    moveModalOpen,
+    confirmOpen,
+    editingSheet,
+    editingBook,
+    setFabHidden,
+  ]);
 
   // ===== 书单：新增 / 重命名 =====
   const openCreateSheet = () => {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -139,9 +139,9 @@ export default function HomePage() {
         setOrientation={setOrientation}
       />
 
-      <main className="max-w-[1200px] mx-auto px-4 pt-4 grid grid-cols-1 lg:grid-cols-12 gap-5">
+      <main className="max-w-[1200px] mx-auto px-4 pt-4 grid grid-cols-1 lg:grid-cols-[1fr,300px] gap-5">
         {/* 左侧：卡片 */}
-        <div className="lg:col-span-9">
+        <div>
           <div className="mb-2 text-sm text-gray-600">
             当前：
             <b>{tab === "hot" ? "热榜（点赞降序）" : "新粮（时间倒序）"}</b>
@@ -159,7 +159,7 @@ export default function HomePage() {
               或检查来源数据是否缺少必填字段（title/category/orientation）。
             </div>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 xl:gap-5">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 xl:gap-5">
               {viewItems.map((item) => (
                 <NovelCard
                   key={item.id || item.title}
@@ -183,7 +183,7 @@ export default function HomePage() {
         </div>
 
         {/* 右侧：排行榜（Top 10）桌面端显示 */}
-        <div className="hidden lg:block lg:col-span-3 space-y-4">
+        <div className="hidden lg:block space-y-4">
           <Leaderboard
             items={viewItems}
             onOpenUser={(u) =>

--- a/src/store/AppStore.jsx
+++ b/src/store/AppStore.jsx
@@ -104,6 +104,7 @@ export function AppProvider({ children }) {
   const [commentsOpen, setCommentsOpen] = useState({ open: false, item: null });
   const [commentsMap, setCommentsMap] = useState({});
   const [editingBook, setEditingBook] = useState(null);
+  const [fabHidden, setFabHidden] = useState(false);
 
   const [tab, setTab] = useState(DEFAULTS.tab);
   const [category, setCategory] = useState(DEFAULTS.category);
@@ -817,6 +818,8 @@ export function AppProvider({ children }) {
       toggleCommentLike,
       editingBook,
       setEditingBook,
+      fabHidden,
+      setFabHidden,
 
       // 筛选
       tab,
@@ -895,6 +898,7 @@ export function AppProvider({ children }) {
       unreadCount,
       moveBookToSheet,
       editingBook,
+      fabHidden,
     ]
   );
 


### PR DESCRIPTION
## Summary
- Ensure desktop cards display in two centered columns with fixed leaderboard sidebar
- Hide floating + button whenever editing, uploading or list dialogs are open

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a27cc32b1083269fc92ff1b8a8e562