### PR TITLE
Fix bookshelf card layout on desktop

### DIFF
--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -142,7 +142,7 @@ export function BookshelfSection() {
       {tab === "sheet" ? (
         <BookSheetPanel />
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 xl:gap-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 xl:gap-5">
           {list.map((item) => (
             <NovelCard
               key={item.id}

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -38,7 +38,7 @@ export default function UserProfilePage() {
       </div>
 
       <div className="mt-6 text-lg font-semibold">TA推荐的书（{recs.length}）</div>
-      <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4">
         {recs.map((item) => (
           <NovelCard
             key={item.id}


### PR DESCRIPTION
## Summary
- make "My Bookshelf" card list responsive with two columns on wide screens
- unify user profile recommendations list to two-column layout

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a27f416f74832680e534ec586f7413