### PR TITLE
fix leaderboard navigation and add pagination & scroll-to-top

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ import CommentsDrawer from "./components/modals/CommentsDrawer";
 import AuthModal from "./components/modals/AuthModal";
 import NotificationsDrawer from "./components/modals/NotificationsDrawer";
 import { useAppStore } from "./store/AppStore";
-import { Plus } from "lucide-react";
+import { Plus, ArrowUp } from "lucide-react";
 import { THEME } from "./lib/theme";
 import { ToastHost } from "./components/ui/Toast";
 
@@ -47,6 +47,13 @@ function Shell() {
     user,
     fabHidden,
   } = useAppStore();
+
+  const [showTop, setShowTop] = React.useState(false);
+  React.useEffect(() => {
+    const onScroll = () => setShowTop(window.scrollY > 200);
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
 
   // 发布上传（保持原有本地插卡行为；UploadDrawer 里也已接上后端，二者兼容）
   const onSubmitUpload = ({
@@ -110,23 +117,42 @@ function Shell() {
 
       {/* 右下角悬浮 + 按钮：编辑/评论/上传时隐藏，避免遮挡输入 */}
       {!(commentsOpen.open || showUpload || editingBook || fabHidden) && (
-        <button
-          onClick={() => (user ? setShowUpload(true) : setAuthOpen(true))}
-          title="闪电上传"
-          className="fixed bottom-6 right-6 rounded-full shadow-lg flex items-center justify-center"
-          style={{
-            width: 56,
-            height: 56,
-            background:
-              "linear-gradient(135deg, #F86C8B 0%, #FFA2B6 60%, #FFD0DA 100%)",
-            boxShadow: THEME.shadowHover,
-            border: `1px solid ${THEME.border}`,
-            color: "#fff",
-            zIndex: 60,
-          }}
-        >
-          <Plus className="w-7 h-7" />
-        </button>
+        <>
+          {showTop && (
+            <button
+              onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+              title="返回顶部"
+              className="fixed right-6 rounded-full shadow-md flex items-center justify-center"
+              style={{
+                width: 40,
+                height: 40,
+                bottom: 80,
+                background: THEME.surface,
+                border: `1px solid ${THEME.border}`,
+                zIndex: 50,
+              }}
+            >
+              <ArrowUp className="w-5 h-5" />
+            </button>
+          )}
+          <button
+            onClick={() => (user ? setShowUpload(true) : setAuthOpen(true))}
+            title="闪电上传"
+            className="fixed bottom-6 right-6 rounded-full shadow-lg flex items-center justify-center"
+            style={{
+              width: 56,
+              height: 56,
+              background:
+                "linear-gradient(135deg, #F86C8B 0%, #FFA2B6 60%, #FFD0DA 100%)",
+              boxShadow: THEME.shadowHover,
+              border: `1px solid ${THEME.border}`,
+              color: "#fff",
+              zIndex: 60,
+            }}
+          >
+            <Plus className="w-7 h-7" />
+          </button>
+        </>
       )}
 
       {/* 全局弹层 */}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -55,6 +55,7 @@ export default function Header(props) {
   const [q, setQ] = useState(store.search || "");
   const triggerSearch = () => {
     store.setSearch((q || "").trim());
+    store.setPage(1);
     if (!isHome) nav("/");
   };
 

--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -103,11 +103,14 @@ export default function Leaderboard({ items = [], onOpenUser, fetcher }) {
 
         <div className="space-y-3">
           {list.map((u, i) => {
-            const displayNick = u.name || u.nick;
+            const displayNick = u.nick || u.nickname || u.name;
             return (
               <button
                 key={(displayNick || "u") + i}
-                onClick={() => onOpenUser && onOpenUser({ nick: displayNick, avatar: u.avatar })}
+                onClick={() =>
+                  onOpenUser &&
+                  onOpenUser({ nick: displayNick, avatar: u.avatar })
+                }
                 className="w-full text-left flex items-center gap-3 rounded-xl px-2 py-2 transition"
                 style={{
                   background: i < 3 ? "rgba(254,243,199,0.45)" : "#FFFFFF",

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { THEME } from "../lib/theme";
+
+export default function Pagination({ page, size, total, onChange }) {
+  const pages = Math.ceil(total / size);
+  if (pages <= 1) return null;
+  const nums = Array.from({ length: pages }, (_, i) => i + 1);
+  return (
+    <div className="mt-6 flex items-center justify-center gap-2 flex-wrap">
+      <button
+        type="button"
+        disabled={page === 1}
+        onClick={() => onChange(page - 1)}
+        className="px-3 py-1.5 rounded-full border text-sm"
+        style={{
+          borderColor: THEME.border,
+          background: THEME.surface,
+          opacity: page === 1 ? 0.5 : 1,
+        }}
+      >
+        上一页
+      </button>
+      {nums.map((n) => (
+        <button
+          key={n}
+          type="button"
+          onClick={() => onChange(n)}
+          className="px-3 py-1.5 rounded-full border text-sm"
+          style={{
+            borderColor: THEME.border,
+            background: n === page ? THEME.rose : THEME.surface,
+            color: n === page ? "#fff" : "#374151",
+          }}
+        >
+          {n}
+        </button>
+      ))}
+      <button
+        type="button"
+        disabled={page === pages}
+        onClick={() => onChange(page + 1)}
+        className="px-3 py-1.5 rounded-full border text-sm"
+        style={{
+          borderColor: THEME.border,
+          background: THEME.surface,
+          opacity: page === pages ? 0.5 : 1,
+        }}
+      >
+        下一页
+      </button>
+    </div>
+  );
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -7,6 +7,7 @@ import { useAppStore } from "../store/AppStore";
 import FilterBar from "../components/FilterBar";
 import Leaderboard from "../components/Leaderboard";
 import NovelCard from "../components/NovelCard";
+import Pagination from "../components/Pagination";
 import { THEME } from "../lib/theme";
 
 // 用 hooks 拉取后端 /api/books
@@ -36,16 +37,20 @@ export default function HomePage() {
     search,
 
     // 分页
-    page, size,
+    page,
+    size,
+    setPage,
     setEditingBook,
   } = useAppStore();
 
   // —— 拉取列表 —— //
+  const isTagSearch = (search || "").startsWith("#");
   const { data: res, isLoading } = useBooks({
     tab,
     category: category === "全部" ? undefined : category,
     orientation: orientation === "全部" ? undefined : orientation,
-    search: search || undefined,
+    search: !isTagSearch && search ? search : undefined,
+    tag: isTagSearch ? search.slice(1) : undefined,
     page,
     size,
   });
@@ -159,26 +164,37 @@ export default function HomePage() {
               或检查来源数据是否缺少必填字段（title/category/orientation）。
             </div>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 xl:gap-5">
-              {viewItems.map((item) => (
-                <NovelCard
-                  key={item.id || item.title}
-                  item={item}
-                  liked={hasId(likedIds, item.id)}            // ✅ 刷新后即可高亮
-                  saved={hasId(savedIds, item.id)}            // ✅ 刷新后即可高亮
-                  onLike={() => handleLike(item)}             // 再次点击即取消
-                  onToggleSave={() => handleToggleSave(item)} // 再次点击即取消
-                  onOpenDetail={() => nav(`/book/${encodeURIComponent(item.id)}`)}
-                  onOpenComments={() => setCommentsOpen({ open: true, item })}
-                  onOpenUser={(u) =>
-                    nav(`/u/${encodeURIComponent(u.nick)}`, {
-                      state: { avatar: u.avatar },
-                    })
-                  }
-                  onEdit={() => setEditingBook(item)}
-                />
-              ))}
-            </div>
+            <>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 xl:gap-5">
+                {viewItems.map((item) => (
+                  <NovelCard
+                    key={item.id || item.title}
+                    item={item}
+                    liked={hasId(likedIds, item.id)}            // ✅ 刷新后即可高亮
+                    saved={hasId(savedIds, item.id)}            // ✅ 刷新后即可高亮
+                    onLike={() => handleLike(item)}             // 再次点击即取消
+                    onToggleSave={() => handleToggleSave(item)} // 再次点击即取消
+                    onOpenDetail={() => nav(`/book/${encodeURIComponent(item.id)}`)}
+                    onOpenComments={() => setCommentsOpen({ open: true, item })}
+                    onOpenUser={(u) =>
+                      nav(`/u/${encodeURIComponent(u.nick)}`, {
+                        state: { avatar: u.avatar },
+                      })
+                    }
+                    onEdit={() => setEditingBook(item)}
+                  />
+                ))}
+              </div>
+              <Pagination
+                page={page}
+                size={size}
+                total={total}
+                onChange={(p) => {
+                  setPage(p);
+                  window.scrollTo({ top: 0, behavior: "smooth" });
+                }}
+              />
+            </>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- ensure leaderboard avatar navigation passes proper nickname field
- add pagination (20 items/page) on home page
- restore scroll-to-top arrow above upload button
- support tag-based search using `#tag`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3677536ac83269d6b535ce92ec8b3