### PR TITLE
fix: filter user recommendations

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -83,6 +83,7 @@ export type BooksQuery = {
   search?: string;
   tag?: string;
   recommender?: string;
+  recommenderId?: number;
   page?: number;
   size?: number;
 };

--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -109,7 +109,7 @@ export default function Leaderboard({ items = [], onOpenUser, fetcher }) {
                 key={(displayNick || "u") + i}
                 onClick={() =>
                   onOpenUser &&
-                  onOpenUser({ nick: displayNick, avatar: u.avatar })
+                  onOpenUser({ nick: displayNick, avatar: u.avatar, id: u.id })
                 }
                 className="w-full text-left flex items-center gap-3 rounded-xl px-2 py-2 transition"
                 style={{

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -178,7 +178,7 @@ export default function HomePage() {
                     onOpenComments={() => setCommentsOpen({ open: true, item })}
                     onOpenUser={(u) =>
                       nav(`/u/${encodeURIComponent(u.nick)}`, {
-                        state: { avatar: u.avatar },
+                        state: { avatar: u.avatar, userId: u.id },
                       })
                     }
                     onEdit={() => setEditingBook(item)}
@@ -204,7 +204,7 @@ export default function HomePage() {
             items={viewItems}
             onOpenUser={(u) =>
               nav(`/u/${encodeURIComponent(u.nick)}`, {
-                state: { avatar: u.avatar },
+                state: { avatar: u.avatar, userId: u.id },
               })
             }
           />
@@ -227,7 +227,7 @@ export default function HomePage() {
               items={viewItems}
               onOpenUser={(u) =>
                 nav(`/u/${encodeURIComponent(u.nick)}`, {
-                  state: { avatar: u.avatar },
+                  state: { avatar: u.avatar, userId: u.id },
                 })
               }
             />

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -14,12 +14,14 @@ export default function UserProfilePage() {
 
   const [page, setPage] = React.useState(1);
   const size = 20;
-  const { data: res, isLoading } = useBooks({
-    recommender: displayNick,
+  const userId = location.state?.userId;
+  const query = {
     page,
     size,
     tab: "new",
-  });
+    ...(userId ? { recommenderId: userId } : { recommender: displayNick }),
+  };
+  const { data: res, isLoading } = useBooks(query);
   const data = res?.data || res || {};
   const recs = data.list ?? data.items ?? [];
   const total = data.total ?? recs.length ?? 0;


### PR DESCRIPTION
## Summary
- pass user id when navigating from avatars to user profile
- filter books on profile page by recommenderId to show only selected user's recommendations
- extend BooksQuery with recommenderId

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a396aa562083269ad58d21245767bf