### PR TITLE
refine filter bar and dropdowns

### DIFF
--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -79,8 +79,7 @@ export default function FilterBar(props) {
             <button
               type="button"
               onClick={handleReset}
-              className="px-3 py-1.5 rounded-full border text-sm hidden sm:block"
-              style={{ borderColor: THEME.border, background: THEME.surface }}
+              className="text-sm text-gray-500 hover:text-rose-500 hidden sm:block"
               title="清空筛选条件"
             >
               重置

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -63,10 +63,10 @@ export default function Header(props) {
     const t = setTimeout(() => {
       store.setSearch((q || "").trim());
       store.setPage(1);
-      if (!isHome) nav("/");
+      if (pathname !== "/") nav("/");
     }, 300);
     return () => clearTimeout(t);
-  }, [q, isHome, nav, store]);
+  }, [q]);
 
   // 点击品牌：回首页 + 清空筛选/搜索 + 默认“新粮”
   const goHomeReset = () => {

--- a/src/components/modals/BottomSheetForm.jsx
+++ b/src/components/modals/BottomSheetForm.jsx
@@ -190,6 +190,7 @@ export default function BottomSheetForm({
                         value={form.orientation}
                         onChange={handleChange("orientation")}
                         options={ORIENTATIONS}
+                        placeholder="请选择性向"
                       />
                     </div>
                     <div>
@@ -198,6 +199,7 @@ export default function BottomSheetForm({
                         value={form.category}
                         onChange={handleChange("category")}
                         options={CATEGORIES}
+                        placeholder="请选择类别"
                       />
                     </div>
                   </div>

--- a/src/components/modals/EditBookDrawer.jsx
+++ b/src/components/modals/EditBookDrawer.jsx
@@ -337,6 +337,7 @@ export default function EditBookDrawer({ open, bookId, onClose }) {
                     onChange={(e) => setOrientation(e.target.value)}
                     options={ORIENTATIONS}
                     disabled={submitting || expired}
+                    placeholder="请选择性向"
                   />
                 </div>
                 <div>
@@ -346,6 +347,7 @@ export default function EditBookDrawer({ open, bookId, onClose }) {
                     onChange={(e) => setCategory(e.target.value)}
                     options={CATEGORIES}
                     disabled={submitting || expired}
+                    placeholder="请选择类别"
                   />
                 </div>
               </div>

--- a/src/components/modals/UploadDrawer.jsx
+++ b/src/components/modals/UploadDrawer.jsx
@@ -306,6 +306,7 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
                     value={orientation}
                     onChange={(e) => setOrientation(e.target.value)}
                     options={ORIENTATIONS}
+                    placeholder="请选择性向"
                   />
                 </div>
                 <div>
@@ -314,6 +315,7 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
                     value={category}
                     onChange={(e) => setCategory(e.target.value)}
                     options={CATEGORIES}
+                    placeholder="请选择类别"
                   />
                 </div>
               </div>

--- a/src/components/ui/CuteSelect.jsx
+++ b/src/components/ui/CuteSelect.jsx
@@ -1,7 +1,23 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { THEME } from "../../lib/theme";
 
-export default function CuteSelect({ value, onChange, options = [], disabled = false, className = "" }) {
+export default function CuteSelect({
+  value,
+  onChange,
+  options = [],
+  disabled = false,
+  className = "",
+  placeholder,
+}) {
+  const list = useMemo(() => {
+    const arr = options.map((opt) =>
+      typeof opt === "string" ? { value: opt, label: opt } : opt
+    );
+    return placeholder
+      ? [{ value: "", label: placeholder, disabled: true }, ...arr]
+      : arr;
+  }, [options, placeholder]);
+
   return (
     <div className={"relative " + className}>
       <select
@@ -11,23 +27,18 @@ export default function CuteSelect({ value, onChange, options = [], disabled = f
         className="w-full appearance-none border rounded-xl px-3 py-2 pr-8 bg-white/70 focus:outline-none focus:ring-2 focus:ring-rose-200 transition"
         style={{ borderColor: THEME.border }}
       >
-        {options.map((opt) => {
-          if (typeof opt === "string") {
-            return (
-              <option key={opt} value={opt}>
-                {opt}
-              </option>
-            );
-          }
-          return (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          );
-        })}
+        {list.map((opt) => (
+          <option
+            key={opt.value}
+            value={opt.value}
+            disabled={opt.disabled}
+          >
+            {opt.label}
+          </option>
+        ))}
       </select>
       <svg
-        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-rose-400"
+        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-gray-400"
         width="16"
         height="16"
         viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- lighten filter bar reset button for a cleaner layout
- make select inputs accept placeholders and use them in upload/edit forms
- avoid header search effect redirect that bounced user profile views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3a891c818832696d1046a17552e54