### PR TITLE
Enlarge blurb textareas and polish reset button

### DIFF
--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -1,5 +1,6 @@
 // 筛选条（类别 & 性向）— 选中态更醒目，类别与性向使用不同的高亮色
 import React, { useState } from "react";
+import { RotateCcw } from "lucide-react";
 import { THEME } from "../lib/theme";
 import { useAppStore } from "../store/AppStore";
 import { CATEGORIES, ORIENTATIONS } from "../lib/constants";
@@ -79,10 +80,11 @@ export default function FilterBar(props) {
             <button
               type="button"
               onClick={handleReset}
-              className="text-sm text-gray-500 hover:text-rose-500 hidden sm:block"
+              className="hidden sm:inline-flex items-center gap-1 px-3 py-1.5 rounded-full border border-rose-200 bg-rose-50 text-sm text-rose-500 hover:bg-rose-100 hover:text-rose-600 transition"
               title="清空筛选条件"
             >
-              重置
+              <RotateCcw className="w-4 h-4" />
+              <span>重置</span>
             </button>
             <button
               type="button"
@@ -94,7 +96,7 @@ export default function FilterBar(props) {
             </button>
             {menuOpen && (
               <div
-                className="absolute right-0 mt-2 w-20 rounded-md border bg-white shadow-md"
+                className="absolute right-0 mt-2 w-24 rounded-md border bg-white shadow-md p-2"
                 style={{ borderColor: THEME.border }}
               >
                 <button
@@ -103,9 +105,10 @@ export default function FilterBar(props) {
                     handleReset();
                     setMenuOpen(false);
                   }}
-                  className="block w-full px-2 py-1 text-left text-sm hover:bg-gray-50"
+                  className="w-full px-3 py-1.5 flex items-center justify-center gap-1 text-sm text-rose-500 rounded-full hover:bg-rose-50"
                 >
-                  重置
+                  <RotateCcw className="w-4 h-4" />
+                  <span>重置</span>
                 </button>
               </div>
             )}

--- a/src/components/modals/EditBookDrawer.jsx
+++ b/src/components/modals/EditBookDrawer.jsx
@@ -355,13 +355,13 @@ export default function EditBookDrawer({ open, bookId, onClose }) {
               <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
                 <div>
                   <label className="text-sm text-gray-600">推荐语</label>
-                  <input
+                  <textarea
                     value={blurb}
                     onChange={(e) => {
                       setBlurb(e.target.value);
                       setErrors((er) => ({ ...er, blurb: null }));
                     }}
-                    className="w-full border rounded-xl px-3 py-2 bg-white/70"
+                    className="w-full border rounded-xl px-3 py-2 h-20 bg-white/70 resize-y"
                     placeholder="一句话强推理由（建议≤60字）"
                     style={{ borderColor: errors.blurb ? "#f43f5e" : THEME.border }}
                     disabled={submitting || expired}

--- a/src/components/modals/UploadDrawer.jsx
+++ b/src/components/modals/UploadDrawer.jsx
@@ -323,10 +323,10 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
               <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
                 <div>
                   <label className="text-sm text-gray-600">推荐语</label>
-                <input
+                  <textarea
                     value={blurb}
                     onChange={(e) => setBlurb(e.target.value)}
-                    className="w-full border rounded-xl px-3 py-2 bg白/70"
+                    className="w-full border rounded-xl px-3 py-2 h-20 bg白/70 resize-y"
                     placeholder="一句话强推理由（建议≤60字）"
                     style={{ borderColor: THEME.border }}
                   />


### PR DESCRIPTION
## Summary
- Allow recommending blurb fields to be resized and match summary area size in upload and edit drawers
- Restyle filter reset button with a rounded, icon-enhanced look for a cuter UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3ad6697ac8326ad6a163fd43b5324