### PR TITLE
feat: support summary and tags in personal sheet books

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -190,6 +190,8 @@ export interface SheetBook {
   category?: string;
   rating?: number;
   review?: string;
+  summary?: string;
+  tags?: string[];
   createdAt?: string | number;
 }
 

--- a/src/components/modals/BottomSheetForm.jsx
+++ b/src/components/modals/BottomSheetForm.jsx
@@ -33,7 +33,7 @@ export default function BottomSheetForm({
         if (saved) data = JSON.parse(saved);
       } catch {}
     }
-    const { cover, coverUrl, ...rest } = data;
+    const { cover, coverUrl, tags: restTags, ...rest } = data;
     setForm({
       name: "",
       intro: "",
@@ -45,7 +45,9 @@ export default function BottomSheetForm({
       rating: "",
       review: "",
       summary: "",
-      tags: "",
+      tags: Array.isArray(restTags)
+        ? restTags.join(",")
+        : restTags || "",
       ...rest,
     });
     setErrors({});
@@ -79,7 +81,14 @@ export default function BottomSheetForm({
 
   const handleSubmit = () => {
     if (!validate()) return;
-    const { cover, coverUrl, ...payload } = form;
+    const { cover, coverUrl, tags, ...payload } = form;
+    if (typeof tags === "string") {
+      const arr = tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean);
+      if (arr.length) payload.tags = arr;
+    }
     onSubmit(payload);
     try {
       localStorage.removeItem(storageKey);

--- a/src/components/modals/SheetBookDetailModal.jsx
+++ b/src/components/modals/SheetBookDetailModal.jsx
@@ -116,7 +116,7 @@ export default function SheetBookDetailModal({ open, book, onClose }) {
                   </div>
 
                   <div className="flex items-center gap-2 ml-auto">
-                    {book?.orientation && (
+                  {book?.orientation && (
                       <span className="px-2.5 py-1 rounded-full bg-pink-50 text-pink-600 text-xs border border-pink-100">
                         <Tag className="inline -mt-[3px] mr-1 h-4 w-4" />
                         {book.orientation}
@@ -131,11 +131,32 @@ export default function SheetBookDetailModal({ open, book, onClose }) {
                   </div>
                 </div>
 
+                {Array.isArray(book?.tags) && book.tags.length > 0 && (
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    {book.tags.map((tag, idx) => (
+                      <span
+                        key={idx}
+                        className="px-2.5 py-1 rounded-full bg-gray-50 text-gray-600 text-xs border border-gray-100"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
                 {/* 一句话推荐 */}
                 {book?.review && (
                   <div className="mt-5 rounded-2xl border border-[#F7E3EA] bg-[#FFF6F8] p-5 relative">
                     <Quote className="h-5 w-5 text-pink-400 absolute -top-3 -left-3 rotate-12" />
                     <div className="text-sm text-gray-700 leading-6">{book.review}</div>
+                  </div>
+                )}
+
+                {book?.summary && (
+                  <div className="mt-5 rounded-2xl border border-[#F7E3EA] bg-[#FFF6F8] p-5">
+                    <div className="text-sm text-gray-700 leading-6 whitespace-pre-wrap">
+                      {book.summary}
+                    </div>
                   </div>
                 )}
 


### PR DESCRIPTION
## Summary
- allow sheet books to include summary and custom tags
- parse tag strings when saving to a book sheet
- show saved tags and summary in SheetBookDetailModal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3cda357d08326a381850aa067f4e2