### PR TITLE
Show actor nickname in notifications

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -254,7 +254,13 @@ export interface NotificationItem {
   read: boolean;
   createdAt: string | number;
   /** 触发者 */
-  actor?: { id: number; nick: string; avatar?: string };
+  actor?: {
+    id: number;
+    nick?: string;
+    nickname?: string;
+    name?: string;
+    avatar?: string;
+  };
   /** 关联书籍/评论 ID */
   bookId?: number;
   bookTitle?: string;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -52,7 +52,13 @@ export interface Notification {
   content?: string;
   read: boolean;
   createdAt: string;
-  actor?: { id: number; nick?: string; name?: string; avatar?: string };
+  actor?: {
+    id: number;
+    nick?: string;
+    nickname?: string;
+    name?: string;
+    avatar?: string;
+  };
   bookId?: number;
   bookTitle?: string;
   commentId?: number;

--- a/src/components/modals/NotificationsDrawer.jsx
+++ b/src/components/modals/NotificationsDrawer.jsx
@@ -183,7 +183,11 @@ export default function NotificationsDrawer({ open, onClose }) {
   };
 
   const renderText = (n) => {
-    const who = n.actor?.nick || n.actor?.name || "有人";
+    const who =
+      n.actor?.nick ||
+      n.actor?.nickname ||
+      n.actor?.name ||
+      "有人";
     const book = n.bookTitle || "作品";
     const excerpt = n.content || "";
     switch (n.type) {
@@ -400,7 +404,12 @@ export default function NotificationsDrawer({ open, onClose }) {
                       <div className="relative">
                         <img
                           src={n.actor.avatar}
-                          alt={n.actor?.nick || n.actor?.name || "avatar"}
+                          alt={
+                            n.actor?.nick ||
+                            n.actor?.nickname ||
+                            n.actor?.name ||
+                            "avatar"
+                          }
                           className={classNames(
                             "w-9 h-9 rounded-full object-cover border",
                             n.read ? "border-gray-200" : "border-rose-200"


### PR DESCRIPTION
## Summary
- display actor nickname when available in notifications
- support actor nickname in Notification types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3d74041308326914cc503f5177655