### PR TITLE
feat: add tag filters

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -82,6 +82,8 @@ export type BooksQuery = {
   orientation?: string;
   search?: string;
   tag?: string;
+  includeTags?: string[];
+  excludeTags?: string[];
   recommender?: string;
   recommenderId?: number;
   page?: number;
@@ -89,13 +91,17 @@ export type BooksQuery = {
 };
 
 export const bookApi = {
-  list: (params: BooksQuery) =>
-    http.get<{
+  list: (params: BooksQuery) => {
+    const p: Record<string, any> = { ...params };
+    if (Array.isArray(p.includeTags)) p.includeTags = p.includeTags.join(',');
+    if (Array.isArray(p.excludeTags)) p.excludeTags = p.excludeTags.join(',');
+    return http.get<{
       list: BookSummary[];
       page: number;
       size: number;
       total: number;
-    }>('/api/books', { params }),
+    }>('/api/books', { params: p });
+  },
 
   detail: (id: number) => http.get<BookSummary>(`/api/books/${id}`),
 
@@ -225,6 +231,13 @@ export const sheetApi = {
 
 // --------------- Tags --------------------
 export const tagApi = {
+  list: (params: { search?: string; page?: number; size?: number; sort?: string }) =>
+    http.get<{
+      list: { id: number; name: string; hot?: number }[];
+      page: number;
+      size: number;
+      total: number;
+    }>('/api/tags', { params }),
   suggest: (q: string) =>
     http.get<string[]>('/api/tags/suggest', { params: { q } }),
   create: (payload: { name: string }) =>

--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -1,9 +1,11 @@
 // 筛选条（类别 & 性向）— 选中态更醒目，类别与性向使用不同的高亮色
-import React, { useState } from "react";
-import { RotateCcw } from "lucide-react";
+import React, { useState, useEffect } from "react";
+import { RotateCcw, Plus, Minus, ChevronDown } from "lucide-react";
 import { THEME } from "../lib/theme";
 import { useAppStore } from "../store/AppStore";
 import { CATEGORIES, ORIENTATIONS } from "../lib/constants";
+import { tagApi } from "../api/sdk";
+import { showToast } from "./ui/Toast";
 
 function Pill({ active, onClick, label, kind = "cat" }) {
   // kind: "cat" | "ori"  -> 用于区分不同选中颜色
@@ -39,6 +41,11 @@ export default function FilterBar(props) {
   const store = useAppStore();
 
   const [menuOpen, setMenuOpen] = useState(false);
+  const [tagPanelOpen, setTagPanelOpen] = useState(false);
+  const [tagQuery, setTagQuery] = useState("");
+  const [tagList, setTagList] = useState([]);
+  const [loadingTags, setLoadingTags] = useState(false);
+  const [tagError, setTagError] = useState(null);
 
   const category = props.category ?? store.category;
   const setCategory = props.setCategory ?? store.setCategory;
@@ -46,10 +53,71 @@ export default function FilterBar(props) {
   const orientation = props.orientation ?? store.orientation;
   const setOrientation = props.setOrientation ?? store.setOrientation;
 
+  const includeTags = props.includeTags ?? store.includeTags;
+  const setIncludeTags = props.setIncludeTags ?? store.setIncludeTags;
+  const excludeTags = props.excludeTags ?? store.excludeTags;
+  const setExcludeTags = props.setExcludeTags ?? store.setExcludeTags;
+
+  const handleInclude = (name) => {
+    if (includeTags.includes(name)) {
+      setIncludeTags(includeTags.filter((t) => t !== name));
+      return;
+    }
+    if (excludeTags.includes(name)) {
+      setExcludeTags(excludeTags.filter((t) => t !== name));
+      showToast("已从排除移至包含");
+    }
+    setIncludeTags([...includeTags, name]);
+  };
+
+  const handleExclude = (name) => {
+    if (excludeTags.includes(name)) {
+      setExcludeTags(excludeTags.filter((t) => t !== name));
+      return;
+    }
+    if (includeTags.includes(name)) {
+      setIncludeTags(includeTags.filter((t) => t !== name));
+      showToast("已从包含移至排除");
+    }
+    setExcludeTags([...excludeTags, name]);
+  };
+
   const handleReset = () => {
     setCategory("全部");
     setOrientation("全部");
+    setIncludeTags([]);
+    setExcludeTags([]);
   };
+
+  useEffect(() => {
+    if (!tagPanelOpen) return;
+    const ctrl = { aborted: false };
+    const timer = setTimeout(async () => {
+      setLoadingTags(true);
+      setTagError(null);
+      try {
+        const res = await tagApi.list({
+          search: tagQuery || undefined,
+          page: 1,
+          size: 50,
+          sort: 'hot',
+        });
+        const data = res?.data || res || {};
+        if (!ctrl.aborted) setTagList(data.list || []);
+      } catch (e) {
+        if (!ctrl.aborted) {
+          setTagList([]);
+          setTagError(e);
+        }
+      } finally {
+        if (!ctrl.aborted) setLoadingTags(false);
+      }
+    }, 300);
+    return () => {
+      ctrl.aborted = true;
+      clearTimeout(timer);
+    };
+  }, [tagPanelOpen, tagQuery]);
 
   return (
     <div
@@ -129,6 +197,140 @@ export default function FilterBar(props) {
               />
             ))}
           </div>
+        </div>
+
+        {/* 标签 */}
+        <div className="mt-3">
+          <div className="flex items-center gap-2">
+            <div className="text-sm text-gray-600 shrink-0">标签：</div>
+            <button
+              type="button"
+              onClick={() => setTagPanelOpen((v) => !v)}
+              className="flex items-center text-sm text-gray-600"
+            >
+              {tagPanelOpen ? "收起" : "展开"}
+              <ChevronDown
+                className={`w-4 h-4 ml-1 transition-transform ${tagPanelOpen ? "rotate-180" : ""}`}
+              />
+            </button>
+          </div>
+          {tagPanelOpen && (
+            <div className="mt-2 space-y-2">
+              <input
+                type="text"
+                value={tagQuery}
+                onChange={(e) => setTagQuery(e.target.value)}
+                placeholder="搜索标签（支持拼音/首字母）"
+                className="w-full px-3 py-1.5 border rounded-md text-sm"
+                style={{ borderColor: THEME.border }}
+              />
+              <div className="max-h-40 overflow-y-auto flex flex-wrap gap-2 text-sm">
+                {loadingTags ? (
+                  <div className="text-gray-500">加载中...</div>
+                ) : tagError ? (
+                  <div className="text-gray-500">
+                    标签加载失败，请重试
+                    <button
+                      type="button"
+                      className="ml-1 text-rose-500 underline"
+                      onClick={() => setTagQuery(tagQuery)}
+                    >
+                      重试
+                    </button>
+                  </div>
+                ) : tagList.length === 0 ? (
+                  <div className="text-gray-500">无匹配标签</div>
+                ) : (
+                  tagList.map((t) => (
+                    <div
+                      key={t.id || t.name}
+                      className={`px-2 py-1 rounded-full border flex items-center gap-1 ${includeTags.includes(t.name) || excludeTags.includes(t.name) ? "text-white shadow-sm" : ""}`}
+                      style={{
+                        background: includeTags.includes(t.name)
+                          ? "linear-gradient(135deg, #FDE68A 0%, #FBBF24 100%)"
+                          : excludeTags.includes(t.name)
+                          ? "linear-gradient(135deg, #FCA5A5 0%, #F87171 100%)"
+                          : THEME.surface,
+                        borderColor: THEME.border,
+                        boxShadow:
+                          includeTags.includes(t.name) || excludeTags.includes(t.name)
+                            ? THEME.shadow
+                            : "none",
+                      }}
+                    >
+                      <span className="whitespace-nowrap">{t.name}</span>
+                      <button
+                        type="button"
+                        className="w-4 h-4 flex items-center justify-center rounded-full border text-xs bg-white"
+                        style={{ borderColor: THEME.border }}
+                        onClick={() => handleInclude(t.name)}
+                        aria-label="包含标签"
+                        title="包含标签"
+                      >
+                        <Plus className="w-3 h-3" />
+                      </button>
+                      <button
+                        type="button"
+                        className="w-4 h-4 flex items-center justify-center rounded-full border text-xs bg-white"
+                        style={{ borderColor: THEME.border }}
+                        onClick={() => handleExclude(t.name)}
+                        aria-label="排除标签"
+                        title="排除标签"
+                      >
+                        <Minus className="w-3 h-3" />
+                      </button>
+                    </div>
+                  ))
+                )}
+              </div>
+              {(includeTags.length > 0 || excludeTags.length > 0) && (
+                <div className="pt-2 space-y-1 text-sm">
+                  {includeTags.length > 0 && (
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-gray-600">包含：</span>
+                      {includeTags.map((t) => (
+                        <button
+                          key={t}
+                          className="px-2 py-1 rounded-full border flex items-center gap-1"
+                          style={{ borderColor: THEME.border, background: THEME.surface }}
+                          onClick={() => handleInclude(t)}
+                        >
+                          {t}
+                          <span className="ml-1">×</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  {excludeTags.length > 0 && (
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-gray-600">排除：</span>
+                      {excludeTags.map((t) => (
+                        <button
+                          key={t}
+                          className="px-2 py-1 rounded-full border flex items-center gap-1"
+                          style={{ borderColor: THEME.border, background: THEME.surface }}
+                          onClick={() => handleExclude(t)}
+                        >
+                          {t}
+                          <span className="ml-1">×</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  <button
+                    type="button"
+                    className="text-xs text-rose-500 underline"
+                    onClick={() => {
+                      setIncludeTags([]);
+                      setExcludeTags([]);
+                    }}
+                  >
+                    清空标签筛选
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -35,6 +35,8 @@ export default function HomePage() {
     // 筛选（仍由全局 Store 管）
     tab, category, orientation, setCategory, setOrientation,
     search,
+    includeTags,
+    excludeTags,
 
     // 分页
     page,
@@ -49,6 +51,8 @@ export default function HomePage() {
     tab,
     category: category === "全部" ? undefined : category,
     orientation: orientation === "全部" ? undefined : orientation,
+    includeTags: includeTags.length ? includeTags : undefined,
+    excludeTags: excludeTags.length ? excludeTags : undefined,
     search: !isTagSearch && search ? search : undefined,
     tag: isTagSearch ? search.slice(1) : undefined,
     page,
@@ -152,6 +156,12 @@ export default function HomePage() {
             <b>{tab === "hot" ? "热榜（点赞降序）" : "新粮（时间倒序）"}</b>
             {category && category !== "全部" && <> · 类别：<b>{category}</b></>}
             {orientation && orientation !== "全部" && <> · 性向：<b>{orientation}</b></>}
+            {includeTags.length > 0 && (
+              <> · 包含：<b>{includeTags.join(',')}</b></>
+            )}
+            {excludeTags.length > 0 && (
+              <> · 排除：<b>{excludeTags.join(',')}</b></>
+            )}
             {search && <> · 搜索：<b>{search}</b></>}
             <span className="ml-2">共 {total} 条</span>
           </div>
@@ -160,8 +170,9 @@ export default function HomePage() {
             <div className="text-sm text-gray-500 py-8">加载中...</div>
           ) : viewItems.length === 0 ? (
             <div className="text-sm text-gray-500 py-8">
-              暂无数据。你可以点击左上角“LOGO”回首页清空筛选，
-              或检查来源数据是否缺少必填字段（title/category/orientation）。
+              {includeTags.length || excludeTags.length
+                ? "未找到匹配书籍，试试调整标签或清空筛选"
+                : "暂无数据。你可以点击左上角“LOGO”回首页清空筛选，或检查来源数据是否缺少必填字段（title/category/orientation）。"}
             </div>
           ) : (
             <>


### PR DESCRIPTION
## Summary
- extend API client to support tag include/exclude queries and tag list
- add collapsible tag panel with search and include/exclude chips to `FilterBar`
- track tag selections in global store and apply them on `HomePage`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a67082395c83269ca4018cad928f82