### PR TITLE
feat: load all tags once and add local pinyin search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.11.0",
         "framer-motion": "^11.18.2",
         "lucide-react": "^0.441.0",
+        "pinyin-match": "^1.2.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.30.1"
@@ -2517,6 +2518,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/pinyin-match": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/pinyin-match/-/pinyin-match-1.2.8.tgz",
+      "integrity": "sha512-5rBwNuOjnOtZNEgX4OlTLYsmBcE9XSV1oF/KN9mLEsVNr8HdqMb2YRhR6iqHMeU8ZBKbx/oYBgHr04uIvOlxGg==",
+      "license": "SATA"
     },
     "node_modules/pirates": {
       "version": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.11.0",
     "framer-motion": "^11.18.2",
     "lucide-react": "^0.441.0",
+    "pinyin-match": "^1.2.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.1"


### PR DESCRIPTION
## Summary
- load full tag list on first panel open
- add pinyin-based local tag search
- make tag pool scrollable and mobile-friendly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a678720b808326a13e60545da2af15