### PR TITLE
feat: auto translate ui strings

### DIFF
--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -7,6 +7,7 @@ import { useAppStore } from '../store/AppStore';
 import { CATEGORIES, ORIENTATIONS } from '../lib/constants';
 import { tagApi } from '../api/sdk';
 import { showToast } from './ui/Toast';
+import { useLanguage } from '../i18n';
 
 function Pill({ active, onClick, label, kind = 'cat' }) {
   // kind: "cat" | "ori" -> 仅视觉区分不同选中颜色
@@ -43,6 +44,7 @@ function Pill({ active, onClick, label, kind = 'cat' }) {
  */
 export default function FilterBar(props) {
   const store = useAppStore();
+  const { t } = useLanguage();
 
   const [tagPanelOpen, setTagPanelOpen] = useState(false);
   const [tagQuery, setTagQuery] = useState('');
@@ -223,7 +225,7 @@ export default function FilterBar(props) {
                   return (
                     <div className="h-44 sm:h-48 overflow-auto flex flex-wrap content-start gap-2 text-sm w-full pr-1">
                       {loadingTags ? (
-                        <div className="text-gray-500 m-2">加载中...</div>
+                        <div className="text-gray-500 m-2">{t('loading')}</div>
                       ) : tagError ? (
                         <div className="text-gray-500 m-2">
                           标签加载失败，请重试

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -19,6 +19,8 @@ import { THEME } from "../lib/theme";
 import { classNames } from "../lib/utils";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useAppStore } from "../store/AppStore";
+import { useLanguage } from "../i18n";
+import LanguageToggle from "./LanguageToggle";
 
 function FilterPill({ active, onClick, icon, label, grad }) {
   return (
@@ -50,6 +52,7 @@ export default function Header(props) {
   const tab = store.tab;
   const setTab = store.setTab;
   const onOpenUpload = props.onOpenUpload ?? (() => store.setShowUpload(true));
+  const { t } = useLanguage();
 
   // 搜索
   const [q, setQ] = useState(store.search || "");
@@ -144,7 +147,7 @@ export default function Header(props) {
               value={q}
               onChange={(e) => setQ(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && triggerSearch()}
-              placeholder="搜索 书名/作者/标签"
+              placeholder={t("searchPlaceholder")}
               className="w-56 outline-none bg-transparent"
             />
             <button
@@ -152,9 +155,9 @@ export default function Header(props) {
               onClick={triggerSearch}
               className="px-3 py-1 rounded-full text-white"
               style={{ background: "linear-gradient(135deg, #F472B6 0%, #FB7185 100%)" }}
-              title="搜索"
+              title={t("search")}
             >
-              搜索
+              {t("search")}
             </button>
           </div>
 
@@ -163,7 +166,7 @@ export default function Header(props) {
             onClick={() => setMobileSearchOpen(true)}
             className="md:hidden p-2 rounded-md hover:bg-rose-50"
             type="button"
-            title="搜索"
+            title={t("search")}
           >
             <Search className="w-6 h-6" />
           </button>
@@ -173,10 +176,12 @@ export default function Header(props) {
             onClick={() => setMobileMenuOpen(true)}
             className="md:hidden p-2 rounded-md hover:bg-rose-50"
             type="button"
-            title="菜单"
+            title={t("menu")}
           >
             <Menu className="w-6 h-6" />
           </button>
+
+          <LanguageToggle />
 
           {/* 闪电上传 */}
           <button
@@ -190,7 +195,7 @@ export default function Header(props) {
             type="button"
           >
             <Upload className="w-4 h-4" />
-            闪电上传
+            {t("quickUpload")}
           </button>
 
           {/* 登录 / 个人中心（带下拉） */}

--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useLanguage } from "../i18n";
+
+export default function LanguageToggle() {
+  const { lang, toggle } = useLanguage();
+  return (
+    <label className="inline-flex items-center cursor-pointer ml-2">
+      <span className="mr-2 text-sm">{lang === "zh" ? "中文" : "EN"}</span>
+      <input
+        type="checkbox"
+        className="sr-only"
+        checked={lang === "en"}
+        onChange={toggle}
+      />
+      <div className="w-10 h-5 bg-gray-300 rounded-full relative">
+        <div
+          className={`w-5 h-5 bg-white rounded-full shadow absolute top-0 transition-all ${
+            lang === "en" ? "left-5" : "left-0"
+          }`}
+        />
+      </div>
+    </label>
+  );
+}

--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Crown } from "lucide-react";
 import { THEME } from "../lib/theme";
 import { aggregateUserHeat } from "../lib/utils";
+import { useLanguage } from "../i18n";
 
 /**
  * 销冠 / 新秀 排行榜（默认 Top 10）
@@ -15,6 +16,7 @@ import { aggregateUserHeat } from "../lib/utils";
  */
 export default function Leaderboard({ items = [], onOpenUser, fetcher }) {
   const [tab, setTab] = useState("champion"); // champion | rookie
+  const { t } = useLanguage();
 
   // 后端数据（优先使用）：使用 React Query 以便通过 invalidateQueries 触发实时刷新
   const {
@@ -98,7 +100,7 @@ export default function Leaderboard({ items = [], onOpenUser, fetcher }) {
       {/* 列表 */}
       <div className="p-4">
         {remoteLoading && (
-          <div className="text-sm text-gray-500 px-2 pb-2">加载中…</div>
+          <div className="text-sm text-gray-500 px-2 pb-2">{t("loading")}</div>
         )}
 
         <div className="space-y-3">

--- a/src/components/modals/UploadDrawer.jsx
+++ b/src/components/modals/UploadDrawer.jsx
@@ -10,6 +10,7 @@ import { tagApi, bookApi } from "../../api/sdk";
 import { useAppStore } from "../../store/AppStore";
 import { useCreateBook } from "../../api/hooks";
 import { useQueryClient } from "@tanstack/react-query";
+import { useLanguage } from "../../i18n";
 
 /** 顶部轻提示（2s 自动消失，玻璃风） */
 function Toast({ message = "", type = "success", onClose }) {
@@ -97,6 +98,7 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
   const qc = useQueryClient();
   const createBook = useCreateBook();
   const { user, setPage } = useAppStore();
+  const { t } = useLanguage();
 
   const allBaseTags = useMemo(() => Array.from(new Set(TAGS)), []);
   const [remoteSuggest, setRemoteSuggest] = useState([]);
@@ -174,7 +176,7 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
       const created = res?.data || res || null;
 
       // 轻提示
-      setToast({ msg: "发布成功", type: "success" });
+      setToast({ msg: t("publish_success"), type: "success" });
 
       // 关闭 + 清表单
       setTimeout(() => {
@@ -196,7 +198,7 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
       return created || true;
     } catch (e) {
       console.error("create book failed", e);
-      setToast({ msg: "发布失败", type: "error" });
+      setToast({ msg: t("publish_failed"), type: "error" });
       throw e;
     } finally {
       setSubmitting(false);
@@ -206,7 +208,7 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
   // 点击发布
   const handleSubmit = async () => {
     if (!title.trim()) {
-      setToast({ msg: "请先填写书名", type: "error" });
+      setToast({ msg: t("need_title"), type: "error" });
       return;
     }
     if (submitting) return;
@@ -216,7 +218,7 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
       const resp = await bookApi.checkExist({ title, author });
       const exists = resp?.data?.exists ?? resp?.exists;
       if (exists) {
-        setToast({ msg: "已存在同名书籍", type: "error" });
+        setToast({ msg: t("title_exists"), type: "error" });
         return;
       }
     } catch (e) {
@@ -448,7 +450,7 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
                   style={{ borderColor: THEME.border, background: THEME.surface }}
                   disabled={submitting}
                 >
-                  取消
+                  {t("cancel")}
                 </button>
                 <button
                   onClick={handleSubmit}
@@ -460,7 +462,7 @@ export default function UploadDrawer({ open, onClose, onSubmit }) {
                   }}
                   disabled={submitting}
                 >
-                  {submitting ? "发布中…" : "发布"}
+                  {submitting ? t("publishing") : t("publish")}
                 </button>
               </div>
             </div>

--- a/src/i18n.jsx
+++ b/src/i18n.jsx
@@ -1,0 +1,109 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+
+const resources = {
+  zh: {
+    loading: "加载中...",
+    search: "搜索",
+    searchPlaceholder: "搜索 书名/作者/标签",
+    quickUpload: "闪电上传",
+    cancel: "取消",
+    publish: "发布",
+    publishing: "发布中…",
+    publish_success: "发布成功",
+    publish_failed: "发布失败",
+    need_title: "请先填写书名",
+    title_exists: "已存在同名书籍",
+    menu: "菜单",
+  },
+  en: {
+    loading: "Loading...",
+    search: "Search",
+    searchPlaceholder: "Search title/author/tags",
+    quickUpload: "Lightning Upload",
+    cancel: "Cancel",
+    publish: "Publish",
+    publishing: "Publishing...",
+    publish_success: "Published successfully",
+    publish_failed: "Publish failed",
+    need_title: "Please provide a title",
+    title_exists: "A book with the same title exists",
+    menu: "Menu",
+  },
+};
+
+const cache = JSON.parse(localStorage.getItem("i18nCache") || "{}");
+
+async function translateDocument(lang) {
+  const walker = document.createTreeWalker(
+    document.body,
+    NodeFilter.SHOW_TEXT,
+    null
+  );
+  const tasks = [];
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    const original = node.__i18nOriginal || node.textContent;
+    if (!node.__i18nOriginal) node.__i18nOriginal = original;
+    if (lang === "zh") {
+      node.textContent = original;
+      continue;
+    }
+    if (/\p{Script=Han}/u.test(original.trim())) {
+      let translated = cache[original];
+      if (!translated) {
+        tasks.push(
+          fetch(
+            `https://api.mymemory.translated.net/get?q=${encodeURIComponent(
+              original
+            )}&langpair=zh-CN|en-US`
+          )
+            .then((res) => res.json())
+            .then((data) => {
+              translated = data.responseData.translatedText || original;
+              cache[original] = translated;
+            })
+            .catch(() => {
+              translated = original;
+            })
+            .finally(() => {
+              node.textContent = translated;
+            })
+        );
+      } else {
+        node.textContent = translated;
+      }
+    }
+  }
+  if (tasks.length) {
+    await Promise.all(tasks);
+    localStorage.setItem("i18nCache", JSON.stringify(cache));
+  }
+}
+
+const LanguageContext = createContext();
+
+export function LanguageProvider({ children }) {
+  const [lang, setLang] = useState(localStorage.getItem("lang") || "zh");
+  const t = (key) =>
+    lang === "en" ? resources.en[key] || cache[key] || key : resources.zh[key] || key;
+  const toggle = () => {
+    const next = lang === "zh" ? "en" : "zh";
+    setLang(next);
+    localStorage.setItem("lang", next);
+  };
+  useEffect(() => {
+    translateDocument(lang);
+    const observer = new MutationObserver(() => translateDocument(lang));
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [lang]);
+  return (
+    <LanguageContext.Provider value={{ lang, toggle, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  return useContext(LanguageContext);
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App.jsx";
 import "./index.css";
+import { LanguageProvider } from "./i18n";
 
 // 关键：用命名空间导入，自动兼容不同导出名
 import * as AppStore from "./store/AppStore";
@@ -28,9 +29,11 @@ ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={qc}>
-        <StoreProvider>
-          <App />
-        </StoreProvider>
+        <LanguageProvider>
+          <StoreProvider>
+            <App />
+          </StoreProvider>
+        </LanguageProvider>
       </QueryClientProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -9,6 +9,7 @@ import Leaderboard from "../components/Leaderboard";
 import NovelCard from "../components/NovelCard";
 import Pagination from "../components/Pagination";
 import { THEME } from "../lib/theme";
+import { useLanguage } from "../i18n";
 
 // 用 hooks 拉取后端 /api/books
 import { useBooks } from "../api/hooks";
@@ -16,6 +17,7 @@ import { useBooks } from "../api/hooks";
 export default function HomePage() {
   const nav = useNavigate();
   const qc = useQueryClient();
+  const { t } = useLanguage();
 
   // —— 防重复请求（点赞/收藏）——
   const likePending = React.useRef(new Set());
@@ -167,7 +169,7 @@ export default function HomePage() {
           </div>
 
           {isLoading ? (
-            <div className="text-sm text-gray-500 py-8">加载中...</div>
+            <div className="text-sm text-gray-500 py-8">{t("loading")}</div>
           ) : viewItems.length === 0 ? (
             <div className="text-sm text-gray-500 py-8">
               {includeTags.length || excludeTags.length

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -5,6 +5,7 @@ import NovelCard from "../components/NovelCard";
 import Pagination from "../components/Pagination";
 import { useAppStore } from "../store/AppStore";
 import { useBooks } from "../api/hooks";
+import { useLanguage } from "../i18n";
 
 export default function UserProfilePage() {
   const { nick } = useParams();
@@ -25,6 +26,7 @@ export default function UserProfilePage() {
   const data = res?.data || res || {};
   const recs = data.list ?? data.items ?? [];
   const total = data.total ?? recs.length ?? 0;
+  const { t } = useLanguage();
 
   // 头像：优先用书卡里 recommender.avatar（若能命中），否则占位
   const avatarFromBooks =
@@ -48,7 +50,7 @@ export default function UserProfilePage() {
 
       <div className="mt-6 text-lg font-semibold">TA推荐的书（{total}）</div>
       {isLoading ? (
-        <div className="mt-3 text-sm text-gray-500">加载中...</div>
+        <div className="mt-3 text-sm text-gray-500">{t("loading")}</div>
       ) : (
         <>
           <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary
- auto-translate any Chinese UI text via DOM walker and online translation
- persist translation cache in localStorage for faster language switches

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c208f2c8748326ab8ae27dc1b822d1