### PR TITLE
fix: show target language on language toggle

### DIFF
--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -5,7 +5,7 @@ export default function LanguageToggle() {
   const { lang, toggle } = useLanguage();
   return (
     <label className="inline-flex items-center cursor-pointer ml-2">
-      <span className="mr-2 text-sm">{lang === "zh" ? "中文" : "EN"}</span>
+      <span className="mr-2 text-sm">{lang === "zh" ? "EN" : "中文"}</span>
       <input
         type="checkbox"
         className="sr-only"


### PR DESCRIPTION
## Summary
- flip text in LanguageToggle so button displays the language to switch to

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c21b75e3548326bdd2e70161dc15e4