### PR TITLE
Improve language toggle clarity

### DIFF
--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -1,24 +1,49 @@
 import React from "react";
 import { useLanguage } from "../i18n";
+import { THEME } from "../lib/theme";
+import { classNames } from "../lib/utils";
 
 export default function LanguageToggle() {
-  const { lang, toggle } = useLanguage();
+  const { lang, setLang } = useLanguage();
   return (
-    <label className="inline-flex items-center cursor-pointer ml-2">
-      <span className="mr-2 text-sm">{lang === "zh" ? "EN" : "中文"}</span>
-      <input
-        type="checkbox"
-        className="sr-only"
-        checked={lang === "en"}
-        onChange={toggle}
-      />
-      <div className="w-10 h-5 bg-gray-300 rounded-full relative">
-        <div
-          className={`w-5 h-5 bg-white rounded-full shadow absolute top-0 transition-all ${
-            lang === "en" ? "left-5" : "left-0"
-          }`}
-        />
-      </div>
-    </label>
+    <div
+      className="ml-2 flex rounded-full overflow-hidden border text-sm"
+      style={{ borderColor: THEME.border }}
+    >
+      <button
+        type="button"
+        onClick={() => setLang("zh")}
+        className={classNames(
+          "px-2 py-1 transition-colors",
+          lang === "zh" ? "text-white" : "text-gray-600"
+        )}
+        style={{
+          background:
+            lang === "zh"
+              ? "linear-gradient(135deg, #F86C8B 0%, #FFA2B6 60%, #FFD0DA 100%)"
+              : THEME.surface,
+        }}
+      >
+        中文
+      </button>
+      <button
+        type="button"
+        onClick={() => setLang("en")}
+        className={classNames(
+          "px-2 py-1 transition-colors border-l",
+          lang === "en" ? "text-white" : "text-gray-600"
+        )}
+        style={{
+          background:
+            lang === "en"
+              ? "linear-gradient(135deg, #C084FC 0%, #A78BFA 100%)"
+              : THEME.surface,
+          borderColor: THEME.border,
+        }}
+      >
+        EN
+      </button>
+    </div>
   );
 }
+

--- a/src/i18n.jsx
+++ b/src/i18n.jsx
@@ -116,10 +116,13 @@ export function LanguageProvider({ children }) {
   const [lang, setLang] = useState(localStorage.getItem("lang") || "zh");
   const t = (key) =>
     lang === "en" ? resources.en[key] || cache[key] || key : resources.zh[key] || key;
-  const toggle = () => {
-    const next = lang === "zh" ? "en" : "zh";
+  const change = (next) => {
     setLang(next);
     localStorage.setItem("lang", next);
+  };
+  const toggle = () => {
+    const next = lang === "zh" ? "en" : "zh";
+    change(next);
   };
   useEffect(() => {
     translateDocument(lang);
@@ -128,7 +131,7 @@ export function LanguageProvider({ children }) {
     return () => observer.disconnect();
   }, [lang]);
   return (
-    <LanguageContext.Provider value={{ lang, toggle, t }}>
+    <LanguageContext.Provider value={{ lang, toggle, setLang: change, t }}>
       {children}
     </LanguageContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Add `setLang` to language context and refactor toggle logic
- Redesign language switch into themed dual buttons indicating selected language

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c21c9bc2708326a181a8e0a8678202