### PR TITLE
fix: improve mobile language toggle responsiveness

### DIFF
--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -7,7 +7,7 @@ export default function LanguageToggle() {
   const { lang, setLang } = useLanguage();
   return (
     <div
-      className="ml-2 flex rounded-full overflow-hidden border text-sm"
+      className="ml-2 flex shrink-0 rounded-full overflow-hidden border text-xs sm:text-sm"
       style={{ borderColor: THEME.border }}
     >
       <button


### PR DESCRIPTION
## Summary
- prevent language toggle from shrinking on small screens
- scale text size for mobile to better fit header without affecting desktop

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c21e9d193083269a9ac4b885bfe810