### PR TITLE
fix: improve select options and mobile layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,14 @@ body {
   background-attachment: fixed; /* 滚动更顺滑 */
 }
 
+/* 移动端防止横向滚动造成的空白 */
+@media (max-width: 768px) {
+  html,
+  body {
+    overflow-x: hidden;
+  }
+}
+
 /* 让任何 sticky 的东西都有更高层级，避免被卡片覆盖。
    注意：FilterBar 本次已做成非 sticky，不会受影响；这条仅兜底其它元素。 */
 .sticky {


### PR DESCRIPTION
## Summary
- improve CuteSelect to accept label/value options and keep state strings
- prevent horizontal scroll on mobile for language toggle issues

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c222a2bba8832694f74790c11a26b2