### PR TITLE
Fix book list total and search responsiveness

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -91,16 +91,17 @@ export type BooksQuery = {
 };
 
 export const bookApi = {
-  list: (params: BooksQuery) => {
+  list: async (params: BooksQuery) => {
     const p: Record<string, any> = { ...params };
     if (Array.isArray(p.includeTags)) p.includeTags = p.includeTags.join(',');
     if (Array.isArray(p.excludeTags)) p.excludeTags = p.excludeTags.join(',');
-    return http.get<{
+    const res = await http.get<{
       list: BookSummary[];
       page: number;
       size: number;
       total: number;
     }>('/api/books', { params: p });
+    return res.data;
   },
 
   detail: (id: number) => http.get<BookSummary>(`/api/books/${id}`),

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -56,8 +56,11 @@ export default function Header(props) {
 
   // 搜索
   const [q, setQ] = useState(store.search || "");
+  const inputRef = useRef(null);
   const triggerSearch = () => {
-    store.setSearch((q || "").trim());
+    const val = (inputRef.current?.value ?? q ?? "").trim();
+    setQ(val);
+    store.setSearch(val);
     store.setPage(1);
     if (!isHome) nav("/");
   };
@@ -147,6 +150,7 @@ export default function Header(props) {
           >
             <Search className="w-4 h-4 text-gray-500" />
             <input
+              ref={inputRef}
               value={q}
               onChange={(e) => setQ(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && triggerSearch()}
@@ -288,6 +292,7 @@ export default function Header(props) {
           >
             <Search className="w-4 h-4 text-gray-500" />
             <input
+              ref={inputRef}
               value={q}
               onChange={(e) => setQ(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && triggerSearch()}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -49,7 +49,7 @@ export default function HomePage() {
 
   // —— 拉取列表 —— //
   const isTagSearch = (search || "").startsWith("#");
-  const { data: res, isLoading } = useBooks({
+  const { data, isLoading } = useBooks({
     tab,
     category: category === "全部" ? undefined : category,
     orientation: orientation === "全部" ? undefined : orientation,
@@ -62,9 +62,8 @@ export default function HomePage() {
   });
 
   // 兼容 axios 拦截器（可能把 {code,msg,data} 拍平）
-  const data = res?.data || res || {};
-  const viewItems = data.list ?? data.items ?? [];
-  const total = data.total ?? viewItems.length ?? 0;
+  const viewItems = data?.list ?? data?.items ?? [];
+  const total = data?.total ?? viewItems.length ?? 0;
 
   // 兼容 id 字符串/数字的判断
   const hasId = (set, id) => set.has(id) || set.has(Number(id)) || set.has(String(id));

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -165,7 +165,7 @@ export function BookshelfSection() {
           size: 100,
           ...(user?.id ? { recommenderId: user.id } : { recommender: nick }),
         });
-        const data = res?.data || res || {};
+        const data = res || {};
         const list = data.list ?? data.items ?? [];
         if (!aborted) setMyRecs(list);
       } catch (e) {

--- a/src/store/AppStore.jsx
+++ b/src/store/AppStore.jsx
@@ -646,7 +646,7 @@ export function AppProvider({ children }) {
         page,
         size,
       });
-      const data = res?.data || res || {};
+      const data = res || {};
       const list = data.list ?? data.items ?? [];
       setItems(list);
       setTotal(data.total ?? list.length ?? 0);
@@ -730,7 +730,7 @@ export function AppProvider({ children }) {
           page,
           size,
         });
-        const data = res?.data || res || {};
+        const data = res || {};
         const list = data.list ?? data.items ?? [];
         if (!aborted) {
           setItems(list);


### PR DESCRIPTION
## Summary
- fix bookApi.list to return payload for accurate totals
- update pages and store to handle list data correctly
- improve search box to use latest input for text and tag search

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c24ae147cc832699d7ee82220b496f