### PR TITLE
fix: correct list total and tag filtering

### DIFF
--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -95,6 +95,11 @@ export const bookApi = {
     const p: Record<string, any> = { ...params };
     if (Array.isArray(p.includeTags)) p.includeTags = p.includeTags.join(',');
     if (Array.isArray(p.excludeTags)) p.excludeTags = p.excludeTags.join(',');
+    // 兼容后端可能使用 tagName/tags 作为参数名
+    if (p.tag) {
+      p.tagName = p.tagName || p.tag;
+      p.tags = p.tags || p.tag;
+    }
     const res = await http.get<{
       list: BookSummary[];
       page: number;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -61,9 +61,19 @@ export default function HomePage() {
     size,
   });
 
-  // 兼容 axios 拦截器（可能把 {code,msg,data} 拍平）
-  const viewItems = data?.list ?? data?.items ?? [];
-  const total = data?.total ?? viewItems.length ?? 0;
+  // 兼容 axios 拦截器及不同返回格式
+  const viewItems =
+    data?.list ??
+    data?.items ??
+    data?.data?.list ??
+    data?.data?.items ??
+    [];
+  const total =
+    Number(
+      data?.total ??
+        data?.data?.total ??
+        (Array.isArray(viewItems) ? viewItems.length : 0)
+    );
 
   // 兼容 id 字符串/数字的判断
   const hasId = (set, id) => set.has(id) || set.has(Number(id)) || set.has(String(id));


### PR DESCRIPTION
## Summary
- fix list view to read total count from various response formats
- send multiple tag query param names for compatibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c24eedb9b48326b5cd12cd9c4d7e63