### PR TITLE
fix: refresh new feed after book edit

### DIFF
--- a/src/components/modals/EditBookDrawer.jsx
+++ b/src/components/modals/EditBookDrawer.jsx
@@ -114,7 +114,7 @@ export default function EditBookDrawer({ open, bookId, onClose }) {
   const [remaining, setRemaining] = useState(0);
   const [expired, setExpired] = useState(false);
   const { t } = useLanguage();
-  const { user } = useAppStore();
+  const { user, bumpBookRefresh } = useAppStore();
   const updateBook = useUpdateBook(bookId, user?.id);
 
   const allBaseTags = useMemo(() => Array.from(new Set(TAGS)), []);
@@ -244,6 +244,7 @@ export default function EditBookDrawer({ open, bookId, onClose }) {
     setSubmitting(true);
     try {
       await updateBook.mutateAsync(payload);
+      bumpBookRefresh();
       setToast({ msg: "已更新", type: "success" });
       setTimeout(() => {
         onClose && onClose();

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -45,11 +45,12 @@ export default function HomePage() {
     size,
     setPage,
     setEditingBook,
+    bookRefreshToken,
   } = useAppStore();
 
   // —— 拉取列表 —— //
   const isTagSearch = (search || "").startsWith("#");
-  const { data, isLoading } = useBooks({
+  const { data, isLoading, refetch } = useBooks({
     tab,
     category: category === "全部" ? undefined : category,
     orientation: orientation === "全部" ? undefined : orientation,
@@ -104,6 +105,11 @@ export default function HomePage() {
       b.bookmarks = Math.max(0, Number(b.bookmarks || 0) + inc);
       return b;
     });
+
+  // 书籍更新后刷新首页列表
+  React.useEffect(() => {
+    refetch();
+  }, [bookRefreshToken, refetch]);
 
   /* ---------------- 交互回调 ---------------- */
 

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -100,6 +100,7 @@ export function BookshelfSection() {
     setCommentsOpen,
     setEditingBook,
     user,
+    bookRefreshToken,
   } = useAppStore();
   const { t } = useLanguage();
   const [tab, setTab] = useState("fav"); // fav | rec | sheet
@@ -149,7 +150,7 @@ export function BookshelfSection() {
     return () => {
       aborted = true;
     };
-  }, [user?.id, savedIds]);
+  }, [user?.id, savedIds, bookRefreshToken]);
 
   // 拉取我推荐的书
   useEffect(() => {
@@ -175,7 +176,7 @@ export function BookshelfSection() {
     return () => {
       aborted = true;
     };
-  }, [nick, user?.id]);
+  }, [nick, user?.id, bookRefreshToken]);
 
   const list = tab === "fav" ? favorites : myRecs;
 

--- a/src/store/AppStore.jsx
+++ b/src/store/AppStore.jsx
@@ -133,6 +133,8 @@ export function AppProvider({ children }) {
   const [commentsMap, setCommentsMap] = useState({});
   const [editingBook, setEditingBook] = useState(null);
   const [fabHidden, setFabHidden] = useState(false);
+  const [bookRefreshToken, setBookRefreshToken] = useState(0);
+  const bumpBookRefresh = () => setBookRefreshToken((n) => n + 1);
 
   const [tab, setTab] = useState(DEFAULTS.tab);
   const [category, setCategory] = useState(DEFAULTS.category);
@@ -888,6 +890,8 @@ export function AppProvider({ children }) {
       setEditingBook,
       fabHidden,
       setFabHidden,
+      bookRefreshToken,
+      bumpBookRefresh,
 
       // 筛选
       tab,
@@ -973,6 +977,8 @@ export function AppProvider({ children }) {
       moveBookToSheet,
       editingBook,
       fabHidden,
+      bookRefreshToken,
+      bumpBookRefresh,
     ]
   );
 


### PR DESCRIPTION
## Summary
- refresh home page list when books are edited elsewhere using a global token

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2513f691c83268f9a8a84e0bb031a